### PR TITLE
Add gcstorage tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,8 @@ jobs:
           use-mamba: true
           python-version: ${{ matrix.PYTHON_VERSION }}
           environment-file: environment.yml
-      - shell: bash -x -l {0}
+      - name: Run the unittests
+        shell: bash -x -l {0}
         run: |
           mamba install google-cloud-storage
           pip install --no-deps .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,6 @@ jobs:
       - name: Run the unittests
         shell: bash -x -l {0}
         run: |
-          mamba install google-cloud-storage
           pip install --no-deps .
           docker run -d --name fake-gcs-server -p 4443:4443 fsouza/fake-gcs-server:v1.21.2 -scheme http
           pytest -nauto

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,5 +28,7 @@ jobs:
           environment-file: environment.yml
       - shell: bash -x -l {0}
         run: |
+          mamba install google-cloud-storage
           pip install --no-deps .
+          docker run -d --name fake-gcs-server -p 4443:4443 fsouza/fake-gcs-server:v1.21.2 -scheme http
           pytest -nauto

--- a/environment.yml
+++ b/environment.yml
@@ -13,3 +13,4 @@ dependencies:
   - psycopg2
   - six
   - sqlalchemy
+  - google-cloud-storage

--- a/tests/basic_store.py
+++ b/tests/basic_store.py
@@ -117,7 +117,13 @@ class BasicStore(object):
         with pytest.raises(ValueError):
             store.delete(invalid_key)
 
-    def test_put_file(self, store, key, value):
+    def test_put_file(self, store, key, value, request):
+        if is_emulated_gcstore_test(store):
+            mark = pytest.mark.xfail(
+                reason="Triggers resumable upload, which isn't currently supported by the GC Emulator"
+            )
+            request.node.add_marker(mark)
+
         tmp = tempfile.NamedTemporaryFile(delete=False)
         try:
             tmp.write(value)

--- a/tests/basic_store.py
+++ b/tests/basic_store.py
@@ -15,7 +15,7 @@ from minimalkv.net.gcstore import GoogleCloudStore
 
 def is_emulated_gcstore_test(store):
     return isinstance(store, GoogleCloudStore) and "localhost" in os.environ.get(
-        "STORAGE_EMULATOR_HOST"
+        "STORAGE_EMULATOR_HOST", ""
     )
 
 


### PR DESCRIPTION
Closes #4 

Due to Google Cloud not providing an official emulator and not fully documenting their whole API (particularly resumable uploads), the Fake GCS server has been slightly flaky. I skipped some file-upload tests to make the suite run through.

I'll open a new issue for running the skipped tests against live GCS, once this is merged. Running the whole suite against live is either flaky due to 429s, or very slow due to long sleeps.