### PR TITLE
Fix Python 3.10 PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        PYTHON_VERSION: ["3.6", "3.7", "3.8", "3.9"]
+        PYTHON_VERSION: ["3.6", "3.7", "3.8", "3.9", "3.10"]
     services:
       postgres:
         image: postgres:11

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,8 +52,6 @@ jobs:
     steps:
       - name: Checkout branch
         uses: actions/checkout@v2.1.0
-        with:
-          ref: ${{ github.head_ref }}
       - name: Install Python 3.8
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
           docker-compose up -d
           while ! docker exec mysql mysqladmin status -h 127.0.0.1 -u minimalkv_test --password=minimalkv_test; \
             do sleep 3; done
-          pytest -n auto --dist loadfile -rs --cov=minimalkv --cov-report=xml
+          pytest -n auto --dist loadfile -rs --cov=minimalkv --cov-report=xml --timeout=60
           python setup.py sdist
           python setup.py bdist_wheel
       - name: Publish package

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
           docker-compose up -d
           while ! docker exec mysql mysqladmin status -h 127.0.0.1 -u minimalkv_test --password=minimalkv_test; \
             do sleep 3; done
-          pytest -n auto --dist loadfile -rs --cov=minimalkv --cov-report=xml --timeout 2 -k test_gcloud_store
+          pytest -n auto --dist loadfile -rs --cov=minimalkv --cov-report=xml
           python setup.py sdist
           python setup.py bdist_wheel
       - name: Publish package

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,9 @@ jobs:
           POSTGRES_USER: minimalkv_test
     env:
       SIMPLEKV_CI: 1
+      AWS_ACCESS_KEY_ID: minio
+      AWS_SECRET_ACCESS_KEY: miniostorage
+      AWS_DEFAULT_REGION: us-east-1
     steps:
       - uses: actions/checkout@v2
       - uses: conda-incubator/setup-miniconda@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
           docker-compose up -d
           while ! docker exec mysql mysqladmin status -h 127.0.0.1 -u minimalkv_test --password=minimalkv_test; \
             do sleep 3; done
-          pytest -n auto --dist loadfile -rs --cov=minimalkv --cov-report=xml --timeout=60
+          pytest -n auto --dist loadfile -rs --cov=minimalkv --cov-report=xml --timeout 10
           python setup.py sdist
           python setup.py bdist_wheel
       - name: Publish package

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 name: CI
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   unittest:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
           docker-compose up -d
           while ! docker exec mysql mysqladmin status -h 127.0.0.1 -u minimalkv_test --password=minimalkv_test; \
             do sleep 3; done
-          pytest -n auto --dist loadfile -rs --cov=minimalkv --cov-report=xml --timeout 10
+          pytest -n auto --dist loadfile -rs --cov=minimalkv --cov-report=xml --timeout 2 -k test_gcloud_store
           python setup.py sdist
           python setup.py bdist_wheel
       - name: Publish package

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,6 @@ jobs:
           POSTGRES_USER: minimalkv_test
     env:
       SIMPLEKV_CI: 1
-      AWS_ACCESS_KEY_ID: minio
-      AWS_SECRET_ACCESS_KEY: miniostorage
-      AWS_DEFAULT_REGION: us-east-1
     steps:
       - uses: actions/checkout@v2
       - uses: conda-incubator/setup-miniconda@v2

--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,7 @@ Pipfile.lock
 
 # direnv
 .envrc
+
+# minimalkv
+store/
+exp.py

--- a/.gitignore
+++ b/.gitignore
@@ -105,6 +105,9 @@ Pipfile.lock
 # direnv
 .envrc
 
+# VS Code
+.vscode/
+
 # minimalkv
 store/
 exp.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,28 +1,26 @@
 repos:
-  - repo: https://github.com/psf/black
-    rev: 20.8b1
-    hooks:
-      - id: black
-        language_version: python3
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v2.13.0
-    hooks:
-      - id: pyupgrade
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.812
-    hooks:
-     - id: mypy
+ - repo: https://github.com/Quantco/pre-commit-mirrors-black
+   rev: 22.3.0
+   hooks:
+     - id: black-conda
        args:
-         - --check-untyped-defs
-         - --ignore-missing-imports
-  - repo: https://github.com/pre-commit/mirrors-isort
-    rev: v5.8.0
-    hooks:
-     - id: isort
-       additional_dependencies: [toml]
-       verbose: true
-  -   repo: https://github.com/pycqa/flake8
-      rev: '3.9.1'
-      hooks:
-      -   id: flake8
-          additional_dependencies: [flake8-docstrings, flake8-rst-docstrings]
+         - --safe
+         - --target-version=py38
+ - repo: https://github.com/Quantco/pre-commit-mirrors-flake8
+   rev: v3.8.4
+   hooks:
+    - id: flake8-conda
+      additional_dependencies: [-c, conda-forge, flake8-docstrings=1.5.0, flake8-rst-docstrings=0.0.14]
+ - repo: https://github.com/Quantco/pre-commit-mirrors-isort
+   rev: 5.6.4
+   hooks:
+    - id: isort-conda
+      additional_dependencies: [-c, conda-forge, toml=0.10.2]
+ - repo: https://github.com/Quantco/pre-commit-mirrors-mypy
+   rev: "0.812"
+   hooks:
+    - id: mypy-conda
+ - repo: https://github.com/Quantco/pre-commit-mirrors-pyupgrade
+   rev: 2.10.0
+   hooks:
+    - id: pyupgrade-conda

--- a/boto_credentials.ini
+++ b/boto_credentials.ini
@@ -1,8 +1,11 @@
 [minio-travis-test]
+# AWS minio credentials
 access_key=minio
 secret_key=miniostorage
-connect_func=connect_s3
-host=http://127.0.0.1:9000
-ordinary_calling_format=true
+# AWS minio endpoint
+host=127.0.0.1
 is_secure=false
 port=9000
+# Legacy boto config
+connect_func=connect_s3
+ordinary_calling_format=true

--- a/boto_credentials.ini
+++ b/boto_credentials.ini
@@ -2,7 +2,7 @@
 access_key=minio
 secret_key=miniostorage
 connect_func=connect_s3
-host=127.0.0.1
+host=http://127.0.0.1:9000
 ordinary_calling_format=true
 is_secure=false
 port=9000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   gcs:
-    image: simonbohnen/fake-gcs-server
+    image: fsouza/fake-gcs-server
     container_name: fake-gcs-server
     ports:
     - 4443:4443

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   gcs:
-    image: fsouza/fake-gcs-server
+    image: simonbohnen/fake-gcs-server
     container_name: fake-gcs-server
     ports:
     - 4443:4443

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -34,8 +34,8 @@ source_suffix = ".rst"
 master_doc = "index"
 
 # General information about the project.
-project = u"minimalkv"
-copyright = u"2011-2021, The minimalkv contributors"
+project = "minimalkv"
+copyright = "2011-2021, The minimalkv contributors"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/environment.yml
+++ b/environment.yml
@@ -24,6 +24,6 @@ dependencies:
   - docker-compose
   - pymysql
   - pre-commit
-  - setuptools-scm
+  - setuptools-scm==6.4.2
   - uritools
   - sphinx

--- a/environment.yml
+++ b/environment.yml
@@ -7,8 +7,6 @@ dependencies:
   - dulwich
   - mock
   - pytest
-# TODO remove
-  - pytest-timeout
   - pytest-mock
   - pytest-xdist
   - pytest-cov

--- a/environment.yml
+++ b/environment.yml
@@ -7,6 +7,7 @@ dependencies:
   - dulwich
   - mock
   - pytest
+# TODO remove
   - pytest-timeout
   - pytest-mock
   - pytest-xdist

--- a/environment.yml
+++ b/environment.yml
@@ -17,6 +17,7 @@ dependencies:
   - google-cloud-storage
   - azure-storage-blob
   - boto
+  - boto3
   - pymongo
   - docker-compose
   - pymysql

--- a/environment.yml
+++ b/environment.yml
@@ -7,6 +7,7 @@ dependencies:
   - dulwich
   - mock
   - pytest
+  - pytest-timeout
   - pytest-mock
   - pytest-xdist
   - pytest-cov

--- a/google_cloud_credentials.ini
+++ b/google_cloud_credentials.ini
@@ -1,3 +1,3 @@
 [google-cloud-tests]
 emulator_endpoint=http://localhost:4443
-;credentials_json_path=nice-road-330220-167c4b1bbd12.json
+credentials_json_path=

--- a/google_cloud_credentials.ini
+++ b/google_cloud_credentials.ini
@@ -1,3 +1,3 @@
 [google-cloud-tests]
-emulator_endpoint=http://[::]:4443
+emulator_endpoint=http://localhost:4443
 ;credentials_json_path=nice-road-330220-167c4b1bbd12.json

--- a/google_cloud_credentials.ini
+++ b/google_cloud_credentials.ini
@@ -1,3 +1,3 @@
 [google-cloud-tests]
-emulator_endpoint=http://localhost:4443
+emulator_endpoint=http://[::]:4443
 ;credentials_json_path=nice-road-330220-167c4b1bbd12.json

--- a/google_cloud_credentials.ini
+++ b/google_cloud_credentials.ini
@@ -1,3 +1,3 @@
 [google-cloud-tests]
 emulator_endpoint=http://localhost:4443
-credentials_json_path=
+;credentials_json_path=nice-road-330220-167c4b1bbd12.json

--- a/minimalkv/_store_creation.py
+++ b/minimalkv/_store_creation.py
@@ -153,7 +153,7 @@ def _build_azure_url(
     default_endpoints_protocol=None,
     blob_endpoint=None,
     use_sas=False,
-    **kwargs
+    **kwargs,
 ):
     # TODO: Docstring
     protocol = default_endpoints_protocol or "https"

--- a/minimalkv/_urls.py
+++ b/minimalkv/_urls.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List
 
 from uritools import urisplit
 
-TRUEVALUES = (u"true",)
+TRUEVALUES = ("true",)
 
 
 def url2dict(url: str, raise_on_extra_params: bool = False) -> Dict[str, Any]:
@@ -55,8 +55,8 @@ def url2dict(url: str, raise_on_extra_params: bool = False) -> Dict[str, Any]:
         wrappers = wrap_spec[-1].partition("wrap:")[2]  # remove the 'wrap:' part
         params["wrap"] = wrappers
 
-    if u"create_if_missing" in parsed["query"]:
-        create_if_missing = parsed["query"].pop(u"create_if_missing")[
+    if "create_if_missing" in parsed["query"]:
+        create_if_missing = parsed["query"].pop("create_if_missing")[
             -1
         ]  # use last appearance of key
         params["create_if_missing"] = create_if_missing in TRUEVALUES
@@ -71,8 +71,8 @@ def extract_params(scheme, host, port, path, query, userinfo):  # noqa D
     if scheme in ("memory", "hmemory"):
         return {}
     if scheme in ("redis", "hredis"):
-        path = path[1:] if path.startswith(u"/") else path
-        params = {"host": host or u"localhost"}
+        path = path[1:] if path.startswith("/") else path
+        params = {"host": host or "localhost"}
         if port:
             params["port"] = port
         if userinfo:
@@ -85,16 +85,16 @@ def extract_params(scheme, host, port, path, query, userinfo):  # noqa D
         params = {"type": scheme, "bucket_name": host}
         params["credentials"] = base64.urlsafe_b64decode(credentials_b64.encode())
         if "bucket_creation_location" in query:
-            params[u"bucket_creation_location"] = query.pop(
-                u"bucket_creation_location"
-            )[0]
+            params["bucket_creation_location"] = query.pop("bucket_creation_location")[
+                0
+            ]
         return params
     if scheme in ("fs", "hfs"):
         return {"type": scheme, "path": host + path}
     if scheme in ("s3", "hs3"):
         access_key, secret_key = _parse_userinfo(userinfo)
         params = {
-            "host": u"{}:{}".format(host, port) if port else host,
+            "host": "{}:{}".format(host, port) if port else host,
             "access_key": access_key,
             "secret_key": secret_key,
             "bucket": path[1:],
@@ -107,16 +107,16 @@ def extract_params(scheme, host, port, path, query, userinfo):  # noqa D
             "account_key": account_key,
             "container": host,
         }
-        if u"use_sas" in query:
+        if "use_sas" in query:
             params["use_sas"] = True
-        if u"max_connections" in query:
-            params["max_connections"] = int(query.pop(u"max_connections")[-1])
-        if u"socket_timeout" in query:
-            params["socket_timeout"] = query.pop(u"socket_timeout")
-        if u"max_block_size" in query:
-            params["max_block_size"] = query.pop(u"max_block_size")
-        if u"max_single_put_size" in query:
-            params["max_single_put_size"] = query.pop(u"max_single_put_size")
+        if "max_connections" in query:
+            params["max_connections"] = int(query.pop("max_connections")[-1])
+        if "socket_timeout" in query:
+            params["socket_timeout"] = query.pop("socket_timeout")
+        if "max_block_size" in query:
+            params["max_block_size"] = query.pop("max_block_size")
+        if "max_single_put_size" in query:
+            params["max_single_put_size"] = query.pop("max_single_put_size")
         return params
 
     raise ValueError('Unknown storage type "{}"'.format(scheme))
@@ -140,7 +140,7 @@ def _parse_userinfo(userinfo: str) -> List[str]:
 
     """
     if hasattr(userinfo, "split"):
-        parts = userinfo.split(u":", 1)
+        parts = userinfo.split(":", 1)
 
         if len(parts) == 2:
             return parts

--- a/minimalkv/idgen.py
+++ b/minimalkv/idgen.py
@@ -39,7 +39,7 @@ class HashDecorator(StoreDecorator):
 
     """
 
-    def __init__(self, decorated_store, hashfunc=hashlib.sha1, template=u"{}"):
+    def __init__(self, decorated_store, hashfunc=hashlib.sha1, template="{}"):
 
         self.hashfunc = hashfunc
         self._template = template
@@ -135,7 +135,7 @@ class HashDecorator(StoreDecorator):
                         self._template.format(phash.hexdigest()),
                         tmpfile.name,
                         *args,
-                        **kwargs
+                        **kwargs,
                     )  # type: ignore
                 finally:
                     try:
@@ -169,7 +169,7 @@ class UUIDDecorator(StoreDecorator):
     # looked up using :func:`getattr` on the :mod:`uuid` module.
     uuidfunc = "uuid1"
 
-    def __init__(self, store, template=u"{}"):
+    def __init__(self, store, template="{}"):
         super(UUIDDecorator, self).__init__(store)
         self._template = template
 

--- a/minimalkv/net/_azurestore_old.py
+++ b/minimalkv/net/_azurestore_old.py
@@ -21,7 +21,7 @@ def map_azure_exceptions(key=None, exc_pass=()):
     except AzureMissingResourceHttpError as ex:
         if ex.__class__.__name__ not in exc_pass:
             s = str(ex)
-            if s.startswith(u"The specified container does not exist."):
+            if s.startswith("The specified container does not exist."):
                 raise IOError(s)
             raise KeyError(key)
     except AzureHttpError as ex:

--- a/minimalkv/net/boto3store.py
+++ b/minimalkv/net/boto3store.py
@@ -106,7 +106,7 @@ class Boto3Store(KeyValueStore, UrlMixin, CopyMixin):  # noqa D
         if isinstance(bucket, str):
             import boto3
 
-            s3_resource = boto3.resource("s3", endpoint_url="http://127.0.0.1:9000")
+            s3_resource = boto3.resource("s3")
             bucket = s3_resource.Bucket(bucket)
             if bucket not in s3_resource.buckets.all():
                 raise ValueError("invalid s3 bucket name")

--- a/minimalkv/net/boto3store.py
+++ b/minimalkv/net/boto3store.py
@@ -106,7 +106,7 @@ class Boto3Store(KeyValueStore, UrlMixin, CopyMixin):  # noqa D
         if isinstance(bucket, str):
             import boto3
 
-            s3_resource = boto3.resource("s3")
+            s3_resource = boto3.resource("s3", endpoint_url="http://127.0.0.1:9000")
             bucket = s3_resource.Bucket(bucket)
             if bucket not in s3_resource.buckets.all():
                 raise ValueError("invalid s3 bucket name")
@@ -201,10 +201,12 @@ class Boto3Store(KeyValueStore, UrlMixin, CopyMixin):  # noqa D
         else:
             is_public = _public_readable(grants)
         if self.url_valid_time and not is_public:
-            s3_client = boto3.client("s3")
+            s3_client = boto3.client("s3", endpoint_url=self.bucket.meta.client.meta.endpoint_url)
         else:
             s3_client = boto3.client(
-                "s3", config=botocore.client.Config(signature_version=botocore.UNSIGNED)
+                "s3",
+                config=botocore.client.Config(signature_version=botocore.UNSIGNED),
+                endpoint_url=self.bucket.meta.client.meta.endpoint_url
             )
         with map_boto3_exceptions(key=key):
             return s3_client.generate_presigned_url(

--- a/minimalkv/net/boto3store.py
+++ b/minimalkv/net/boto3store.py
@@ -201,12 +201,14 @@ class Boto3Store(KeyValueStore, UrlMixin, CopyMixin):  # noqa D
         else:
             is_public = _public_readable(grants)
         if self.url_valid_time and not is_public:
-            s3_client = boto3.client("s3", endpoint_url=self.bucket.meta.client.meta.endpoint_url)
+            s3_client = boto3.client(
+                "s3", endpoint_url=self.bucket.meta.client.meta.endpoint_url
+            )
         else:
             s3_client = boto3.client(
                 "s3",
                 config=botocore.client.Config(signature_version=botocore.UNSIGNED),
-                endpoint_url=self.bucket.meta.client.meta.endpoint_url
+                endpoint_url=self.bucket.meta.client.meta.endpoint_url,
             )
         with map_boto3_exceptions(key=key):
             return s3_client.generate_presigned_url(

--- a/tests/basic_store.py
+++ b/tests/basic_store.py
@@ -244,26 +244,26 @@ class BasicStore(object):
 
     def test_prefix_iterator(self, store, value):
         for k in [
-            u"X",
-            u"a1Xb1",
-            u"a1Xb1",
-            u"a2X",
-            u"a2Xb1",
-            u"a3",
-            u"a4Xb1Xc1",
-            u"a4Xb1Xc2",
-            u"a4Xb2Xc1",
-            u"a4Xb3",
+            "X",
+            "a1Xb1",
+            "a1Xb1",
+            "a2X",
+            "a2Xb1",
+            "a3",
+            "a4Xb1Xc1",
+            "a4Xb1Xc2",
+            "a4Xb2Xc1",
+            "a4Xb3",
         ]:
             store.put(k, value)
 
-        prefixes = sorted(store.iter_prefixes(u"X"))
-        assert prefixes == [u"X", u"a1X", u"a2X", u"a3", u"a4X"]
+        prefixes = sorted(store.iter_prefixes("X"))
+        assert prefixes == ["X", "a1X", "a2X", "a3", "a4X"]
 
-        prefixes = sorted(store.iter_prefixes(u"X", prefix=u"a4X"))
-        assert prefixes == [u"a4Xb1X", u"a4Xb2X", u"a4Xb3"]
+        prefixes = sorted(store.iter_prefixes("X", prefix="a4X"))
+        assert prefixes == ["a4Xb1X", "a4Xb2X", "a4Xb3"]
 
-        prefixes = sorted(store.iter_prefixes(u"X", prefix=u"foo"))
+        prefixes = sorted(store.iter_prefixes("X", prefix="foo"))
         assert prefixes == []
 
     def test_keys(self, store, key, key2, value, value2):

--- a/tests/basic_store.py
+++ b/tests/basic_store.py
@@ -27,7 +27,6 @@ class BasicStore(object):
         with pytest.raises(IOError):
             store.put(key, unicode_value)
 
-    @pytest.mark.timeout(10)
     def test_store_and_retrieve(self, store, key, value):
         store.put(key, value)
         assert store.get(key) == value

--- a/tests/basic_store.py
+++ b/tests/basic_store.py
@@ -27,6 +27,7 @@ class BasicStore(object):
         with pytest.raises(IOError):
             store.put(key, unicode_value)
 
+    @pytest.mark.timeout(10)
     def test_store_and_retrieve(self, store, key, value):
         store.put(key, value)
         assert store.get(key) == value

--- a/tests/bucket_manager.py
+++ b/tests/bucket_manager.py
@@ -51,7 +51,6 @@ def boto3_bucket(access_key, secret_key, host=None, bucket_name=None, **kwargs):
     name = bucket_name or "testrun-bucket-{}".format(uuid())
     if host == "127.0.0.1":
         host = "http://127.0.0.1:9000"
-    host = host or "http://127.0.0.1:9000"
     s3_client = boto3.client("s3", endpoint_url=host)
     s3_client.create_bucket(Bucket=name)
     s3_resource = boto3.resource("s3", endpoint_url=host)

--- a/tests/bucket_manager.py
+++ b/tests/bucket_manager.py
@@ -45,13 +45,16 @@ def boto_bucket(
 
 
 @contextmanager
-def boto3_bucket(access_key, secret_key, host, bucket_name=None, **kwargs):
+def boto3_bucket(access_key, secret_key, host=None, bucket_name=None, **kwargs):
     import boto3
 
     name = bucket_name or "testrun-bucket-{}".format(uuid())
-    s3_client = boto3.client("s3")
+    if host == "127.0.0.1":
+        host = "http://127.0.0.1:9000"
+    host = host or "http://127.0.0.1:9000"
+    s3_client = boto3.client("s3", endpoint_url=host)
     s3_client.create_bucket(Bucket=name)
-    s3_resource = boto3.resource("s3")
+    s3_resource = boto3.resource("s3", endpoint_url=host)
     bucket = s3_resource.Bucket(name)
 
     yield bucket

--- a/tests/bucket_manager.py
+++ b/tests/bucket_manager.py
@@ -49,9 +49,19 @@ def boto3_bucket(access_key, secret_key, host=None, bucket_name=None, **kwargs):
     import boto3
 
     name = bucket_name or "testrun-bucket-{}".format(uuid())
-    s3_client = boto3.client("s3", endpoint_url=host)
+    s3_client = boto3.client(
+        "s3",
+        endpoint_url=host,
+        aws_access_key_id=access_key,
+        aws_secret_access_key=secret_key,
+    )
     s3_client.create_bucket(Bucket=name)
-    s3_resource = boto3.resource("s3", endpoint_url=host)
+    s3_resource = boto3.resource(
+        "s3",
+        endpoint_url=host,
+        aws_access_key_id=access_key,
+        aws_secret_access_key=secret_key,
+    )
     bucket = s3_resource.Bucket(name)
 
     yield bucket

--- a/tests/bucket_manager.py
+++ b/tests/bucket_manager.py
@@ -45,24 +45,41 @@ def boto_bucket(
 
 
 @contextmanager
-def boto3_bucket(access_key, secret_key, host=None, bucket_name=None, **kwargs):
-    # Set environment variables for boto3
+def boto3_bucket(
+    access_key,
+    secret_key,
+    host=None,
+    bucket_name=None,
+    port=None,
+    is_secure=None,
+    **kwargs,
+):
     import os
 
     import boto3
 
+    # Set environment variables for boto3
     os.environ["AWS_ACCESS_KEY_ID"] = access_key
     os.environ["AWS_SECRET_ACCESS_KEY"] = secret_key
+    os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
+
+    # Build endpoint host
+    endpoint_url = None
+    if host:
+        scheme = "https" if is_secure else "http"
+        endpoint_url = f"{scheme}://{host}"
+        if port:
+            endpoint_url += f":{port}"
 
     name = bucket_name or "testrun-bucket-{}".format(uuid())
     s3_client = boto3.client(
         "s3",
-        endpoint_url=host,
+        endpoint_url=endpoint_url,
     )
     s3_client.create_bucket(Bucket=name)
     s3_resource = boto3.resource(
         "s3",
-        endpoint_url=host,
+        endpoint_url=endpoint_url,
     )
     bucket = s3_resource.Bucket(name)
 

--- a/tests/bucket_manager.py
+++ b/tests/bucket_manager.py
@@ -49,8 +49,6 @@ def boto3_bucket(access_key, secret_key, host=None, bucket_name=None, **kwargs):
     import boto3
 
     name = bucket_name or "testrun-bucket-{}".format(uuid())
-    if host == "127.0.0.1":
-        host = "http://127.0.0.1:9000"
     s3_client = boto3.client("s3", endpoint_url=host)
     s3_client.create_bucket(Bucket=name)
     s3_resource = boto3.resource("s3", endpoint_url=host)

--- a/tests/bucket_manager.py
+++ b/tests/bucket_manager.py
@@ -46,21 +46,23 @@ def boto_bucket(
 
 @contextmanager
 def boto3_bucket(access_key, secret_key, host=None, bucket_name=None, **kwargs):
+    # Set environment variables for boto3
+    import os
+
     import boto3
+
+    os.environ["AWS_ACCESS_KEY_ID"] = access_key
+    os.environ["AWS_SECRET_ACCESS_KEY"] = secret_key
 
     name = bucket_name or "testrun-bucket-{}".format(uuid())
     s3_client = boto3.client(
         "s3",
         endpoint_url=host,
-        aws_access_key_id=access_key,
-        aws_secret_access_key=secret_key,
     )
     s3_client.create_bucket(Bucket=name)
     s3_resource = boto3.resource(
         "s3",
         endpoint_url=host,
-        aws_access_key_id=access_key,
-        aws_secret_access_key=secret_key,
     )
     bucket = s3_resource.Bucket(name)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,7 +30,8 @@ def unicode_value(request):
     return request.param
 
 
-@pytest.fixture(params=[b"a_long_value" * 4 * 1024])
+# TODO make longer again
+@pytest.fixture(params=[b"a_long_value" * 4])
 def long_value(request):
     return request.param
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,7 +25,7 @@ def value2(request):
     return request.param
 
 
-@pytest.fixture(params=[u"the_other_value", u"othäöü_valਊਏਐਓਔਕਖਗue_2"])
+@pytest.fixture(params=["the_other_value", "othäöü_valਊਏਐਓਔਕਖਗue_2"])
 def unicode_value(request):
     return request.param
 
@@ -36,17 +36,17 @@ def long_value(request):
 
 
 # keys are always strings. only ascii chars are allowed
-@pytest.fixture(params=[u"short_key", u"""'!"`#$%&'()+,-.<=>?@[]^_{}~'"""])
+@pytest.fixture(params=["short_key", """'!"`#$%&'()+,-.<=>?@[]^_{}~'"""])
 def key(request):
     return request.param
 
 
-@pytest.fixture(params=[u"key_number_2"])
+@pytest.fixture(params=["key_number_2"])
 def key2(request):
     return request.param
 
 
-@pytest.fixture(params=[u"ä", u"/", u"\x00", u"*", u"", u"no whitespace allowed"])
+@pytest.fixture(params=["ä", "/", "\x00", "*", "", "no whitespace allowed"])
 def invalid_key(request):
     return request.param
 
@@ -57,7 +57,7 @@ def bytestring_key(request):
 
 
 # maximum length key
-@pytest.fixture(params=[u"a" * 250])
+@pytest.fixture(params=["a" * 250])
 def max_key(request):
     return request.param
 
@@ -66,18 +66,18 @@ def max_key(request):
 class ExtendedKeyspaceTests:
     @pytest.fixture(
         params=[
-            u"short ke/y",
-            u"short_key",
-            u"""'!"`#$%&'()+,-.<=>?@[]^_{}~/'""",
+            "short ke/y",
+            "short_key",
+            """'!"`#$%&'()+,-.<=>?@[]^_{}~/'""",
         ]
     )
     def key(self, request):
         return request.param
 
-    @pytest.fixture(params=[u"key_number/2 with space"])
+    @pytest.fixture(params=["key_number/2 with space"])
     def key2(self, request):
         return request.param
 
-    @pytest.fixture(params=[u"ä", u"/", u"\x00", u"*", u""])
+    @pytest.fixture(params=["ä", "/", "\x00", "*", ""])
     def invalid_key(self, request):
         return request.param

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,8 +30,7 @@ def unicode_value(request):
     return request.param
 
 
-# TODO make longer again
-@pytest.fixture(params=[b"a_long_value" * 4])
+@pytest.fixture(params=[b"a_long_value" * 4 * 1024])
 def long_value(request):
     return request.param
 

--- a/tests/idgens.py
+++ b/tests/idgens.py
@@ -15,11 +15,11 @@ UUID_REGEXP = re.compile(
 class IDGen:
     @pytest.fixture(
         params=[
-            u"constant",
-            u"foo{}bar",
-            u"{}.jpeg",
-            u"prefix-{}.hello",
-            u"justprefix{}",
+            "constant",
+            "foo{}bar",
+            "{}.jpeg",
+            "prefix-{}.hello",
+            "justprefix{}",
         ]
     )
     def idgen_template(self, request):

--- a/tests/storefact/test_store_creation.py
+++ b/tests/storefact/test_store_creation.py
@@ -76,17 +76,17 @@ def test_create_store_hs3(mocker):
     create_store(
         "hs3",
         {
-            "host": u"endpoint:1234",
-            "access_key": u"access_key",
-            "secret_key": u"secret_key",
-            "bucket": u"bucketname",
+            "host": "endpoint:1234",
+            "access_key": "access_key",
+            "secret_key": "secret_key",
+            "bucket": "bucketname",
         },
     )
     mock_hs3.assert_called_once_with(
-        host=u"endpoint:1234",
-        access_key=u"access_key",
-        secret_key=u"secret_key",
-        bucket=u"bucketname",
+        host="endpoint:1234",
+        access_key="access_key",
+        secret_key="secret_key",
+        bucket="bucketname",
     )
 
 
@@ -95,17 +95,17 @@ def test_create_store_s3(mocker):
     create_store(
         "s3",
         {
-            "host": u"endpoint:1234",
-            "access_key": u"access_key",
-            "secret_key": u"secret_key",
-            "bucket": u"bucketname",
+            "host": "endpoint:1234",
+            "access_key": "access_key",
+            "secret_key": "secret_key",
+            "bucket": "bucketname",
         },
     )
     mock_s3.assert_called_once_with(
-        host=u"endpoint:1234",
-        access_key=u"access_key",
-        secret_key=u"secret_key",
-        bucket=u"bucketname",
+        host="endpoint:1234",
+        access_key="access_key",
+        secret_key="secret_key",
+        bucket="bucketname",
     )
 
 
@@ -135,7 +135,7 @@ def test_create_store_mem(mocker):
     mock_mem = mocker.patch("minimalkv.memory.DictStore")
     create_store(
         "memory",
-        {"type": u"memory", "wrap": u"readonly"},
+        {"type": "memory", "wrap": "readonly"},
     )
     mock_mem.assert_called_once_with()
 
@@ -144,7 +144,7 @@ def test_create_store_hmem(mocker):
     mock_hmem = mocker.patch("minimalkv._hstores.HDictStore")
     create_store(
         "hmemory",
-        {"type": u"memory", "wrap": u"readonly"},
+        {"type": "memory", "wrap": "readonly"},
     )
     mock_hmem.assert_called_once_with()
 
@@ -153,7 +153,7 @@ def test_create_store_redis(mocker):
     mock_Strictredis = mocker.patch("redis.StrictRedis")
     create_store(
         "redis",
-        {"type": u"redis", "host": u"localhost", "db": 2},
+        {"type": "redis", "host": "localhost", "db": 2},
     )
     mock_Strictredis.assert_called_once_with(db=2, host="localhost", type="redis")
 

--- a/tests/storefact/test_urls.py
+++ b/tests/storefact/test_urls.py
@@ -6,7 +6,7 @@ from minimalkv.decorator import ReadOnlyDecorator
 
 good_urls = [
     (
-        u"azure://MYACCOUNT:dead%2Fbeef@1buc-ket1?param1=foo&param2=🍺&eat_more_🍎=1&create_if_missing=true",
+        "azure://MYACCOUNT:dead%2Fbeef@1buc-ket1?param1=foo&param2=🍺&eat_more_🍎=1&create_if_missing=true",
         dict(
             type="azure",
             account_name="MYACCOUNT",
@@ -16,7 +16,7 @@ good_urls = [
         ),
     ),
     (
-        u"azure://MYACCOUNT:deadbeef@1bucket1?param1=foo&param2=🍺&eat_more_🍎=1&create_if_missing=true",
+        "azure://MYACCOUNT:deadbeef@1bucket1?param1=foo&param2=🍺&eat_more_🍎=1&create_if_missing=true",
         dict(
             type="azure",
             account_name="MYACCOUNT",
@@ -26,7 +26,7 @@ good_urls = [
         ),
     ),
     (
-        u"azure://MYACCOUNT:deadbeef@1bucket1?param1=foo&param2=🍺&eat_more_🍎=&max_connections=5",
+        "azure://MYACCOUNT:deadbeef@1bucket1?param1=foo&param2=🍺&eat_more_🍎=&max_connections=5",
         dict(
             type="azure",
             account_name="MYACCOUNT",
@@ -36,7 +36,7 @@ good_urls = [
         ),
     ),
     (
-        u"azure://MYACCOUNT:deadbeef@1bucket1?param1=foo&param2=🍺&eat_more_🍎=&max_connections=5&max_block_size=4194304&&max_single_put_size=67108864",
+        "azure://MYACCOUNT:deadbeef@1bucket1?param1=foo&param2=🍺&eat_more_🍎=&max_connections=5&max_block_size=4194304&&max_single_put_size=67108864",
         dict(
             type="azure",
             account_name="MYACCOUNT",
@@ -47,26 +47,26 @@ good_urls = [
             max_single_put_size=["67108864"],
         ),
     ),
-    (u"fs://this/is/a/relative/path", dict(type="fs", path="this/is/a/relative/path")),
-    (u"fs:///an/absolute/path", dict(type=u"fs", path=u"/an/absolute/path")),
+    ("fs://this/is/a/relative/path", dict(type="fs", path="this/is/a/relative/path")),
+    ("fs:///an/absolute/path", dict(type="fs", path="/an/absolute/path")),
     (
-        u"s3://access_key:secret_key@endpoint:1234/bucketname",
+        "s3://access_key:secret_key@endpoint:1234/bucketname",
         dict(
-            type=u"s3",
-            host=u"endpoint:1234",
-            access_key=u"access_key",
-            secret_key=u"secret_key",
-            bucket=u"bucketname",
+            type="s3",
+            host="endpoint:1234",
+            access_key="access_key",
+            secret_key="secret_key",
+            bucket="bucketname",
         ),
     ),
-    (u"redis:///2", dict(type=u"redis", host=u"localhost", db=2)),
-    (u"memory://#wrap:readonly", {"type": u"memory", "wrap": u"readonly"}),
-    (u"memory://", dict(type=u"memory")),
+    ("redis:///2", dict(type="redis", host="localhost", db=2)),
+    ("memory://#wrap:readonly", {"type": "memory", "wrap": "readonly"}),
+    ("memory://", dict(type="memory")),
 ]
 
 bad_urls = [
     (
-        u"azure://MYACCOUNT:deadb/eef@1buc-ket1?param1=foo&param2=🍺&eat_more_🍎=1&create_if_missing=true",
+        "azure://MYACCOUNT:deadb/eef@1buc-ket1?param1=foo&param2=🍺&eat_more_🍎=1&create_if_missing=true",
         ValueError,
     ),
 ]
@@ -74,7 +74,7 @@ bad_urls = [
 
 def test_raise_on_invalid_store():
     with pytest.raises(ValueError):
-        url2dict(u"dummy://foo/bar")
+        url2dict("dummy://foo/bar")
 
 
 @pytest.mark.parametrize("url, expected", good_urls)
@@ -90,6 +90,6 @@ def test_bad_url2dict(url, raises):
 
 def test_roundtrip():
     assert isinstance(
-        get_store_from_url(u"memory://#wrap:readonly"),
+        get_store_from_url("memory://#wrap:readonly"),
         ReadOnlyDecorator,
     )

--- a/tests/test_azure_store.py
+++ b/tests/test_azure_store.py
@@ -97,12 +97,12 @@ def test_azure_setgetstate():
     container = str(uuid())
     conn_string = get_azure_conn_string()
     store = AzureBlockBlobStore(conn_string=conn_string, container=container)
-    store.put(u"key1", b"value1")
+    store.put("key1", b"value1")
 
     buf = pickle.dumps(store, protocol=2)
     store = pickle.loads(buf)
 
-    assert store.get(u"key1") == b"value1"
+    assert store.get("key1") == b"value1"
     _delete_container(conn_string, container)
 
 
@@ -155,7 +155,7 @@ class TestAzureExceptionHandling(object):
         )
         with pytest.raises(IOError) as exc:
             store.keys()
-        assert u"The specified container does not exist." in str(exc.value)
+        assert "The specified container does not exist." in str(exc.value)
 
     def test_wrong_endpoint(self):
         container = str(uuid())
@@ -176,8 +176,8 @@ class TestAzureExceptionHandling(object):
             store.blob_container_client._config.retry_policy.total_retries = 0  # type: ignore
 
         with pytest.raises(IOError) as exc:
-            store.put(u"key", b"data")
-        assert u"connect" in str(exc.value)
+            store.put("key", b"data")
+        assert "connect" in str(exc.value)
 
     def test_wrong_credentials(self):
         container = str(uuid())
@@ -198,8 +198,8 @@ class TestAzureExceptionHandling(object):
             store.blob_container_client._config.retry_policy.total_retries = 0  # type: ignore
 
         with pytest.raises(IOError) as exc:
-            store.put(u"key", b"data")
-        assert u"Incorrect padding" in str(exc.value)
+            store.put("key", b"data")
+        assert "Incorrect padding" in str(exc.value)
 
 
 class TestChecksum(object):

--- a/tests/test_boto3_store.py
+++ b/tests/test_boto3_store.py
@@ -21,7 +21,7 @@ def credentials(request):
     return request.param
 
 
-@pytest.yield_fixture()
+@pytest.fixture
 def bucket(credentials):
     with boto3_bucket(**credentials) as bucket:
         yield bucket

--- a/tests/test_boto_store.py
+++ b/tests/test_boto_store.py
@@ -21,7 +21,7 @@ def credentials(request):
     return request.param
 
 
-@pytest.yield_fixture()
+@pytest.fixture
 def bucket(credentials):
     with boto_bucket(**credentials) as bucket:
         yield bucket

--- a/tests/test_bucket_manager.py
+++ b/tests/test_bucket_manager.py
@@ -11,7 +11,7 @@ def credentials(request):
     return request.param
 
 
-@pytest.yield_fixture()
+@pytest.fixture
 def bucket(credentials):
     with boto_bucket(**credentials) as bucket:
         yield bucket

--- a/tests/test_filesystem_store.py
+++ b/tests/test_filesystem_store.py
@@ -56,7 +56,7 @@ class TestFilesystemStoreFileURI(TestBaseFilesystemStore):
             tmpfile.write(value)
             tmpfile.close()
 
-            key = store.put_file(u"testkey", tmpfile.name)
+            key = store.put_file("testkey", tmpfile.name)
             url = store.url_for(key)
 
             assert url.startswith("file://")
@@ -86,7 +86,7 @@ class TestFilesystemStoreUmask(TestBaseFilesystemStore):
     def test_file_permission_on_new_file_have_correct_value(self, store, perms, value):
         src = BytesIO(value)
 
-        key = store.put_file(u"test123", src)
+        key = store.put_file("test123", src)
 
         parts = urlparse(store.url_for(key))
         path = parts.path
@@ -166,41 +166,41 @@ class TestExtendedKeyspaceFilesystemStore(
 
     def test_prefix_iterator_ossep(self, store, value):
         for k in [
-            u"a1" + os.sep + u"b1",
-            u"a1" + os.sep + u"b1",
-            u"a2" + os.sep + u"b1",
-            u"a3",
-            u"a4" + os.sep + u"b1" + os.sep + u"c1",
-            u"a4" + os.sep + u"b1" + os.sep + u"c2",
-            u"a4" + os.sep + u"b2" + os.sep + u"c1",
-            u"a4" + os.sep + u"b3",
+            "a1" + os.sep + "b1",
+            "a1" + os.sep + "b1",
+            "a2" + os.sep + "b1",
+            "a3",
+            "a4" + os.sep + "b1" + os.sep + "c1",
+            "a4" + os.sep + "b1" + os.sep + "c2",
+            "a4" + os.sep + "b2" + os.sep + "c1",
+            "a4" + os.sep + "b3",
         ]:
             store.put(k, value)
 
         out = sorted(store.iter_prefixes(os.sep))
         assert out == [
-            u"a1" + os.sep,
-            u"a2" + os.sep,
-            u"a3",
-            u"a4" + os.sep,
+            "a1" + os.sep,
+            "a2" + os.sep,
+            "a3",
+            "a4" + os.sep,
         ]
 
         out = sorted(
             store.iter_prefixes(
                 os.sep,
-                prefix=u"a4" + os.sep,
+                prefix="a4" + os.sep,
             )
         )
         assert out == [
-            u"a4" + os.sep + "b1" + os.sep,
-            u"a4" + os.sep + "b2" + os.sep,
-            u"a4" + os.sep + "b3",
+            "a4" + os.sep + "b1" + os.sep,
+            "a4" + os.sep + "b2" + os.sep,
+            "a4" + os.sep + "b3",
         ]
 
         out = sorted(
             store.iter_prefixes(
                 os.sep,
-                prefix=u"foo" + os.sep,
+                prefix="foo" + os.sep,
             )
         )
         assert out == []

--- a/tests/test_git_store.py
+++ b/tests/test_git_store.py
@@ -33,7 +33,7 @@ class TestGitCommitStore(BasicStore, UUIDGen, HashGen):
     def test_uses_subdir(self, repo_path, subdir_name, branch):
         store = GitCommitStore(repo_path, branch=branch, subdir=subdir_name)
         # add a key
-        store.put(u"foo", b"bar")
+        store.put("foo", b"bar")
 
         sdir = subdir_name.decode("ascii").strip("/")
 
@@ -50,7 +50,7 @@ class TestGitCommitStore(BasicStore, UUIDGen, HashGen):
         assert repo[blob_id].data == b"bar"
 
         # add a second key, resulting in a new commit and two keys available
-        store.put(u"foo2", b"bar2")
+        store.put("foo2", b"bar2")
 
         fn = "foo"
         if sdir:

--- a/tests/test_hmac.py
+++ b/tests/test_hmac.py
@@ -36,7 +36,7 @@ class TestHMACFileReader(object):
 
     @pytest.fixture
     def chunk_sizes(self, value):
-        return [10 ** n for n in range(2, 8)]
+        return [10**n for n in range(2, 8)]
 
     def test_close(self, create_reader):
         reader = create_reader()
@@ -121,7 +121,7 @@ class HMACDec(object):
 
     def test_copy_raises_not_implemented(self, store):
         with pytest.raises(NotImplementedError):
-            HMACDecorator(b"secret", store).copy(u"src", u"dest")
+            HMACDecorator(b"secret", store).copy("src", "dest")
 
     def test_put_file_obj(self, key, value, hmacstore):
         hmacstore.put_file(key, BytesIO(value))

--- a/tests/test_mongo.py
+++ b/tests/test_mongo.py
@@ -19,7 +19,7 @@ class TestMongoDB(BasicStore):
     def db_name(self):
         return "_minimalkv_test_{}".format(uuid())
 
-    @pytest.yield_fixture
+    @pytest.fixture
     def store(self, db_name):
         try:
             conn = pymongo.MongoClient()

--- a/tests/test_prefix_decorator.py
+++ b/tests/test_prefix_decorator.py
@@ -36,10 +36,10 @@ class TestPrefixDecorator(BasicStore):
 
         # do we add extra keys to the underlying store?
         if request.param:
-            base_store.put(u"some_other_value", b"data1")
-            base_store.put(u"ends_with_short_", b"data2")
-            base_store.put(u"xx", b"data3")
-            base_store.put(u"test", b"data4")
+            base_store.put("some_other_value", b"data1")
+            base_store.put("ends_with_short_", b"data2")
+            base_store.put("xx", b"data3")
+            base_store.put("test", b"data4")
 
         return PrefixDecorator(prefix, base_store)
 

--- a/tests/test_readonly_decorator.py
+++ b/tests/test_readonly_decorator.py
@@ -10,13 +10,13 @@ from minimalkv.memory import DictStore
 class TestReadOnlyDecorator(object):
     def test_readonly(self):
         store0 = DictStore()
-        store0.put(u"file1", b"content")
+        store0.put("file1", b"content")
 
         store = ReadOnlyDecorator(store0)
         with pytest.raises(AttributeError):
-            store.put(u"file1", b"content2")
+            store.put("file1", b"content2")
         with pytest.raises(AttributeError):
-            store.delete(u"file1")
-        assert store.get(u"file1") == b"content"
-        assert u"file1" in store
-        assert set(store.keys()) == {u"file1"}
+            store.delete("file1")
+        assert store.get("file1") == b"content"
+        assert "file1" in store
+        assert set(store.keys()) == {"file1"}

--- a/tests/test_url_encode_keys_decorator.py
+++ b/tests/test_url_encode_keys_decorator.py
@@ -18,14 +18,14 @@ class TestURLEncodeKeysDecorator(BasicStore):
         return URLEncodeKeysDecorator(base_store)
 
     def test_urlencode(self, store):
-        store.put(u"key special:-🍺", b"val1")
-        assert store.get(u"key special:-🍺") == b"val1"
+        store.put("key special:-🍺", b"val1")
+        assert store.get("key special:-🍺") == b"val1"
 
     def test_urlencode_base_store(self, store, base_store, value):
-        store.put(u"abc def/key", value)
-        assert u"abc+def%2Fkey" in base_store
-        assert base_store.get(u"abc+def%2Fkey") == value
-        assert store.get(u"abc def/key") == value
+        store.put("abc def/key", value)
+        assert "abc+def%2Fkey" in base_store
+        assert base_store.get("abc+def%2Fkey") == value
+        assert store.get("abc def/key") == value
 
     # The invalid key is replaced by a valid one after encoding through
     # the decorator...


### PR DESCRIPTION
- add boto3
  - provide credentials for minio via environment variables
  - set endpoint URL correctly in code
- [fix fake-gcs-server](https://github.com/simonbohnen/fake-gcs-server/commit/e0b32a7f729da0e857e973e9c92456791b8f384d) to not send checksums for partial requests (HTTP status 206) and use that version for CI
- pin setuptools-scm to 6.4.2 to be compatible with Python 3.6
  - @xhochy should we drop Python 3.6 support instead?