### PR TITLE
Lazily import gcsfs

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -1,6 +1,11 @@
 Changelog
 *********
 
+1.4.1
+=====
+
+* We now lazily import ``gcsfs``.
+
 1.4.0
 ======
 

--- a/minimalkv/net/gcstore.py
+++ b/minimalkv/net/gcstore.py
@@ -53,7 +53,7 @@ class GoogleCloudStore(FSSpecStore):
 
         super().__init__(prefix=f"{bucket_name}/", mkdir_prefix=create_if_missing)
 
-    def _create_filesystem(self) -> GCSFileSystem:
+    def _create_filesystem(self) -> "GCSFileSystem":
         if not has_gcsfs:
             raise ImportError("Cannot find optional dependency gcsfs.")
 

--- a/minimalkv/net/gcstore.py
+++ b/minimalkv/net/gcstore.py
@@ -2,10 +2,14 @@ import json
 import warnings
 from typing import IO, cast
 
-from gcsfs import GCSFileSystem
-from google.cloud.exceptions import NotFound
-
 from minimalkv.fsspecstore import FSSpecStore, FSSpecStoreEntry
+
+try:
+    from gcsfs import GCSFileSystem
+
+    has_gcsfs = True
+except ImportError:
+    has_gcsfs = False
 
 
 class GoogleCloudStore(FSSpecStore):
@@ -50,6 +54,9 @@ class GoogleCloudStore(FSSpecStore):
         super().__init__(prefix=f"{bucket_name}/", mkdir_prefix=create_if_missing)
 
     def _create_filesystem(self) -> GCSFileSystem:
+        if not has_gcsfs:
+            raise ImportError("Cannot find optional dependency gcsfs.")
+
         return GCSFileSystem(
             project=self.project_name,
             token=self._credentials,
@@ -58,6 +65,8 @@ class GoogleCloudStore(FSSpecStore):
         )
 
     def _open(self, key: str) -> IO:
+        from google.cloud.exceptions import NotFound
+
         if not self._prefix_exists:
             raise NotFound(f"Could not find bucket: {self.bucket_name}")
         return cast(IO, FSSpecStoreEntry(super()._open(key)))


### PR DESCRIPTION
I'm currently running into problems when using kartothek 4.x with the latest minimalkv release. I'm not using google cloud storage so I don't have gcsfs installed.

(Partial) stacktrace:

```
/opt/conda/envs/myenv/lib/python3.9/site-packages/kartothek/io_components/utils.py:277: in normalize_args
    return _wrapper(*args, **kwargs)
/opt/conda/envs/myenv/lib/python3.9/site-packages/kartothek/io_components/utils.py:275: in _wrapper
    return function(*args, **kwargs)
/opt/conda/envs/myenv/lib/python3.9/site-packages/kartothek/io/eager.py:460: in store_dataframes_as_dataset
    return store_dataframes_as_dataset__iter(
/opt/conda/envs/myenv/lib/python3.9/site-packages/decorator.py:232: in fun
    return caller(func, *(extras + args), **kw)
/opt/conda/envs/myenv/lib/python3.9/site-packages/kartothek/io_components/utils.py:277: in normalize_args
    return _wrapper(*args, **kwargs)
/opt/conda/envs/myenv/lib/python3.9/site-packages/kartothek/io_components/utils.py:275: in _wrapper
    return function(*args, **kwargs)
/opt/conda/envs/myenv/lib/python3.9/site-packages/kartothek/io/iter.py:282: in store_dataframes_as_dataset__iter
    raise_if_dataset_exists(dataset_uuid=dataset_uuid, store=store)
/opt/conda/envs/myenv/lib/python3.9/site-packages/kartothek/io_components/write.py:278: in raise_if_dataset_exists
    store_instance = ensure_store(store)
/opt/conda/envs/myenv/lib/python3.9/site-packages/kartothek/core/utils.py:72: in ensure_store
    return lazy_store(store)()
/opt/conda/envs/myenv/lib/python3.9/site-packages/minimalkv/_get_store.py:55: in get_store_from_url
    return get_store(**url2dict(url))
/opt/conda/envs/myenv/lib/python3.9/site-packages/minimalkv/_get_store.py:145: in get_store
    store = create_store(type, params)
/opt/conda/envs/myenv/lib/python3.9/site-packages/minimalkv/_store_creation.py:23: in create_store
    return _create_store_hfs(type, params)
/opt/conda/envs/myenv/lib/python3.9/site-packages/minimalkv/_store_creation.py:114: in _create_store_hfs
    from minimalkv._hstores import HFilesystemStore
/opt/conda/envs/myenv/lib/python3.9/site-packages/minimalkv/_hstores.py:9: in <module>
    from minimalkv.net.gcstore import GoogleCloudStore
```

This PR lazily imports the optional dependencies. 

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a `docs/changes.rst` entry
