### PR TITLE
Monkeypatch quoting

### DIFF
--- a/minimalkv/fsspecstore.py
+++ b/minimalkv/fsspecstore.py
@@ -1,8 +1,5 @@
 import io
-from functools import partial
 from typing import IO, TYPE_CHECKING, Iterator, Optional, Union
-from urllib.parse import quote as _quote
-from urllib.parse import unquote
 
 if TYPE_CHECKING:
     from fsspec import AbstractFileSystem
@@ -10,8 +7,6 @@ if TYPE_CHECKING:
 
 from minimalkv import KeyValueStore
 from minimalkv.net._net_common import LAZY_PROPERTY_ATTR_PREFIX, lazy_property
-
-quote = partial(_quote, safe="")
 
 # The complete path of the key is structured as follows:
 # /Users/simon/data/mykvstore/file1
@@ -83,6 +78,29 @@ class FSSpecStoreEntry(io.BufferedIOBase):
         return self._file.readable()
 
 
+class Quoter:
+    """
+    XXX.
+
+    To support filenames including e.g. `#`, we need to monkeypatch quote methods in here for pytest.
+    To be able to access keys which include e.g. '/' without double escaping, we do nothing here and let gcsfs
+    do the quoting until this PR is released:
+    https://github.com/fsspec/gcsfs/pull/502
+
+    Also see `test_gcloud_store.py` for monkeypatching.
+    """
+
+    @staticmethod
+    def quote(s):
+        """Do nothing here."""
+        return s
+
+    @staticmethod
+    def unquote(s):
+        """Do nothing here."""
+        return s
+
+
 class FSSpecStore(KeyValueStore):
     """A KeyValueStore that uses an fsspec AbstractFileSystem to store the key-value pairs."""
 
@@ -128,38 +146,41 @@ class FSSpecStore(KeyValueStore):
             If there was an error accessing the store.
         """
         # List files
-        all_files_and_dirs = self._fs.find(f"{self.prefix}", prefix=quote(prefix))
+        all_files_and_dirs = self._fs.find(
+            f"{self.prefix}", prefix=Quoter.quote(prefix)
+        )
 
         return map(
-            lambda k: unquote(k.replace(f"{self.prefix}", "")), all_files_and_dirs
+            lambda k: Quoter.unquote(k.replace(f"{self.prefix}", "")),
+            all_files_and_dirs,
         )
 
     def _delete(self, key: str) -> None:
         try:
-            self._fs.rm_file(f"{self.prefix}{quote(key)}")
+            self._fs.rm_file(f"{self.prefix}{Quoter.quote(key)}")
         except FileNotFoundError:
             pass
 
     def _open(self, key: str) -> IO:
         try:
-            return self._fs.open(f"{self.prefix}{quote(key)}")
+            return self._fs.open(f"{self.prefix}{Quoter.quote(key)}")
         except FileNotFoundError:
             raise KeyError(key)
 
     # Required to prevent error when credentials are not sufficient for listing objects
     def _get_file(self, key: str, file: IO) -> str:
         try:
-            file.write(self._fs.cat_file(f"{self.prefix}{quote(key)}"))
+            file.write(self._fs.cat_file(f"{self.prefix}{Quoter.quote(key)}"))
             return key
         except FileNotFoundError:
             raise KeyError(key)
 
     def _put_file(self, key: str, file: IO) -> str:
-        self._fs.pipe_file(f"{self.prefix}{quote(key)}", file.read())
+        self._fs.pipe_file(f"{self.prefix}{Quoter.quote(key)}", file.read())
         return key
 
     def _has_key(self, key: str) -> bool:
-        return self._fs.exists(f"{self.prefix}{quote(key)}")
+        return self._fs.exists(f"{self.prefix}{Quoter.quote(key)}")
 
     def _create_filesystem(self) -> "AbstractFileSystem":
         # To be implemented by inheriting classes.


### PR DESCRIPTION
@DamianBarabonkovQC 

Do avoid double quoting when using minimalkv in a live setting, we replaced the quoting methods with the identity. Thus using e.g. `#` in filenames is not supported until there is a new release for [gcsfs](https://github.com/fsspec/gcsfs/pull/502).

We monkeypatch the quoter in testing (so double-quoting is done for characters like `/` for now), which can be removed later.

This allows access to files whose names contain e.g. `/`, which might be revelant for libraries depending on minimalkv.