### PR TITLE
Extended KeyValueStore and Decorator Baseclasses with closing support

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -1,6 +1,13 @@
 Changelog
 *********
 
+1.5.0
+=====
+
+* Added concept for closable stores.
+  * Stores and Decorators can now be opened using with KeyValueStore as store
+  * Implemented this functionality for baseclasses and the AzureBlockBlobStore
+
 1.4.4
 =====
 

--- a/minimalkv/_key_value_store.py
+++ b/minimalkv/_key_value_store.py
@@ -1,5 +1,6 @@
 from io import BytesIO
-from typing import IO, Iterable, Iterator, List, Optional, Union
+from types import TracebackType
+from typing import IO, Iterable, Iterator, List, Optional, Type, Union
 
 from minimalkv._constants import VALID_KEY_RE
 from minimalkv._mixins import UrlMixin
@@ -433,6 +434,33 @@ class KeyValueStore:
         """
         with open(filename, "rb") as source:
             return self._put_file(key, source)
+
+    def close(self):
+        """Clean up all open resources in child classes.
+
+        Specific store implementations might require teardown methods
+        (dangling ports, unclosed files). This allows calling close also
+        for stores, which do not require this.
+        """
+        return
+
+    def __enter__(self):
+        """Support with clause for automatic calling of close."""
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ):
+        """Support with clause for automatic calling of close.
+
+        :param exc_type: Type of optional exception encountered in context manager
+        :param exc_val: Actual optional exception encountered in context manager
+        :param exc_tb: Traceback of optional exception encountered in context manager
+        """
+        self.close()
 
 
 class UrlKeyValueStore(UrlMixin, KeyValueStore):

--- a/minimalkv/decorator.py
+++ b/minimalkv/decorator.py
@@ -1,4 +1,5 @@
-from typing import Iterable
+from types import TracebackType
+from typing import Iterable, Optional, Type
 from urllib.parse import quote_plus, unquote_plus
 
 from minimalkv._key_value_store import KeyValueStore
@@ -37,6 +38,28 @@ class StoreDecorator:
 
     def __iter__(self) -> Iterable[str]:  # noqa D
         return self._dstore.__iter__()
+
+    def close(self):
+        """Relay a close call to the next decorator or underlying store."""
+        self._dstore.close()
+
+    def __enter__(self):
+        """Provide context manager support."""
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ):
+        """Call close on underlying store or decorator.
+
+        :param exc_type: Type of optional exception encountered in context manager
+        :param exc_val: Actual optional exception encountered in context manager
+        :param exc_tb: Traceback of optional exception encountered in context manager
+        """
+        self.close()
 
 
 class KeyTransformingDecorator(StoreDecorator):  # noqa D

--- a/tests/basic_store.py
+++ b/tests/basic_store.py
@@ -146,7 +146,8 @@ class BasicStore:
             tmp.write(value)
             tmp.flush()
 
-            store.put_file(key, open(tmp.name, "rb"))
+            with open(tmp.name, "rb") as infile:
+                store.put_file(key, infile)
 
             assert store.get(key) == value
 
@@ -156,7 +157,8 @@ class BasicStore:
 
         store.get_file(key, out_filename)
 
-        assert open(out_filename, "rb").read() == value
+        with open(out_filename, "rb") as infile:
+            assert infile.read() == value
 
     def test_get_into_stream(self, store, key, value):
         store.put(key, value)

--- a/tests/test_keyvaluestore_base.py
+++ b/tests/test_keyvaluestore_base.py
@@ -1,0 +1,10 @@
+from unittest import mock
+
+from minimalkv import KeyValueStore
+
+
+def test_keyvaluestore_enter_exit():
+    with mock.patch("minimalkv.KeyValueStore.close") as closefunc:
+        with KeyValueStore() as kv:  # noqa F841
+            pass
+        closefunc.assert_called_once()

--- a/tests/test_mongo.py
+++ b/tests/test_mongo.py
@@ -24,7 +24,8 @@ class TestMongoDB(BasicStore):
             conn = pymongo.MongoClient()
         except pymongo.errors.ConnectionFailure:
             pytest.skip("could not connect to mongodb")
-        yield MongoStore(conn[db_name], "minimalkv-tests")
+        with MongoStore(conn[db_name], "minimalkv-tests") as store:
+            yield store
         conn.drop_database(db_name)
 
 
@@ -38,5 +39,6 @@ class TestExtendedKeyspaceDictStore(TestMongoDB, ExtendedKeyspaceTests):
             conn = pymongo.MongoClient()
         except pymongo.errors.ConnectionFailure:
             pytest.skip("could not connect to mongodb")
-        yield ExtendedKeyspaceStore(conn[db_name], "minimalkv-tests")
+        with ExtendedKeyspaceStore(conn[db_name], "minimalkv-tests") as store:
+            yield store
         conn.drop_database(db_name)

--- a/tests/test_redis.py
+++ b/tests/test_redis.py
@@ -25,7 +25,8 @@ class TestRedisStore(TTLStore, BasicStore):
             pytest.skip("Could not connect to redis server")
 
         r.flushdb()
-        yield RedisStore(r)
+        with RedisStore(r) as store:
+            yield store
         r.flushdb()
 
 
@@ -45,5 +46,6 @@ class TestExtendedKeyspaceDictStore(TestRedisStore, ExtendedKeyspaceTests):
             pytest.skip("Could not connect to redis server")
 
         r.flushdb()
-        yield ExtendedKeyspaceStore(r)
+        with ExtendedKeyspaceStore(r) as store:
+            yield store
         r.flushdb()

--- a/tests/test_sqlalchemy.py
+++ b/tests/test_sqlalchemy.py
@@ -42,10 +42,10 @@ class TestSQLAlchemyStore(BasicStore):
     @pytest.fixture
     def store(self, engine):
         metadata = MetaData(bind=engine)
-        store = SQLAlchemyStore(engine, metadata, "minimalkv_test")
-        # create table
-        store.table.create()
-        yield store
+        with SQLAlchemyStore(engine, metadata, "minimalkv_test") as store:
+            # create table
+            store.table.create()
+            yield store
         metadata.drop_all()
 
 
@@ -56,8 +56,8 @@ class TestExtendedKeyspaceSQLAlchemyStore(TestSQLAlchemyStore, ExtendedKeyspaceT
             pass
 
         metadata = MetaData(bind=engine)
-        store = ExtendedKeyspaceStore(engine, metadata, "minimalkv_test")
-        # create table
-        store.table.create()
-        yield store
+        with ExtendedKeyspaceStore(engine, metadata, "minimalkv_test") as store:
+            # create table
+            store.table.create()
+            yield store
         metadata.drop_all()


### PR DESCRIPTION
### Motivation

minimalkv does not have a possibility to **close** a store, if opening it requires opening e.g. file descriptors or ports. This can for example be observed in the Azure blobstore unit tests, when turning on ResourceWarnings, which generates 400 warnings and  2500 lines noting that ports were not closed:

```
pytest -Wonce tests/test_azure_store.py
============================================================================================== test session starts ==============================================================================================
platform linux -- Python 3.10.6, pytest-7.1.3, pluggy-1.0.0
rootdir: /home/me/src/minimalkv
collected 250 items

.../python3.10/site-packages/_pytest/runner.py:136: ResourceWarning: unclosed <socket.socket fd=12, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6, laddr=('127.0.0.1', 46992), raddr=('127.0.0.1', 10000)>
    item.funcargs = None  # type: ignore[attr-defined]

... 2500 lines omitted ...

=============================================================================== 208 passed, 42 skipped, 418 warnings in 9.92s ================================================================================
```
When using minimalkv in another project, it is currently impossible to close these stores manually and one will observe the same warnings. This gets even worse, if the store is wrapped behind multiple decorators so that one has no clue anymore, which type of store is actually instantiated

### Solution
In this PR we extend the **KeyValueStore** and **Decorator** baseclasses with closing support and implement the baseclass in the _azurestore_new store as an example. 

With the implementation we can do
```
with MyKeyValueStoreClass() as kv:
    kv.dothings()
```
and it will automatically close. Manual closing via kv.close() is also supported.

With this change (and actually closing the stores) the warning count of test_azure_store.py is now 0 again:
```
pytest -Wonce tests/test_azure_store.py
============================================================================================== test session starts ==============================================================================================
platform linux -- Python 3.10.6, pytest-7.1.3, pluggy-1.0.0
rootdir: /home/ctfy/src/minimalkv
collected 253 items

tests/test_azure_store.py ................................................ssssssssssssssssssssssssssssssssssss......ssssss...............ssssssssssssssssss.............................................. [ 24%]
...................................................................................................................................................................................................ssssss [ 52%]
ssssssssssssssssssssssssssssssssssssssssss........ssssssss.................ssssssssssssssssssss.......................................................................................................... [ 81%]
......................................................................................................................................                                                                    [100%]

======================================================================================= 211 passed, 42 skipped in 5.08s =======================================================================================
```

Full disclosure: I made this PR against simplekv not knowing it was unmaintained and only changed the numbers in the two pytest outputs.


Checklist
* [x] Added a `docs/changes.rst` entry
