### PR TITLE
Revert to old fake gcs server

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   gcs:
-    image: simonbohnen/fake-gcs-server
+    image: fsouza/fake-gcs-server
     container_name: fake-gcs-server
     ports:
     - 4443:4443

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,7 +56,10 @@ def bytestring_key(request):
 
 
 # maximum length key
-@pytest.fixture(params=["a" * 250])
+# 230 is chosen because the fake-gcs-server stores the objects in the filesystem
+# and appends a hash for uniqueness. The hash is roughly 15 bytes long, and the maximum filename length is 255.
+# The maximum object name length for live S3 and GCS is 1024 bytes.
+@pytest.fixture(params=["a" * 230])
 def max_key(request):
     return request.param
 


### PR DESCRIPTION
As https://github.com/googleapis/google-resumable-media-python/pull/361 was fixed and is part of a [new release](https://github.com/googleapis/google-resumable-media-python/releases/tag/v2.4.1), we don't need my patch on the `fake-gcs-server` side anymore and can use the version by fsouza.
