### PR TITLE
Fix custom endpoint specification for S3Store

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -1,6 +1,10 @@
 Changelog
 *********
 
+1.8.0
+=====
+* Fixed the behaviour of ``S3FSStore`` when providing a custom endpoint.
+
 1.7.0
 =====
 * Deprecated ``get_store``, ``url2dict``, and ``extract_params``.

--- a/minimalkv/memory/__init__.py
+++ b/minimalkv/memory/__init__.py
@@ -1,6 +1,8 @@
 from io import BytesIO
 from typing import Dict, Iterator, Optional
 
+from uritools import SplitResult
+
 from minimalkv import CopyMixin, KeyValueStore
 
 
@@ -43,3 +45,9 @@ class DictStore(KeyValueStore, CopyMixin):
 
         """
         return filter(lambda k: k.startswith(prefix), iter(self.d))
+
+    @classmethod
+    def _from_parsed_url(
+        cls, parsed_url: SplitResult, query: Dict[str, str]
+    ) -> "DictStore":
+        return cls()

--- a/minimalkv/net/s3fsstore.py
+++ b/minimalkv/net/s3fsstore.py
@@ -66,17 +66,14 @@ class S3FSStore(FSSpecStore, UrlMixin):  # noqa D
         if not has_s3fs:
             raise ImportError("Cannot find optional dependency s3fs.")
 
-        if "127.0.0.1" in self.endpoint_url:
-            return S3FileSystem(
-                anon=False,
-                client_kwargs={
-                    "endpoint_url": self.endpoint_url,
-                },
-            )
-        else:
-            return S3FileSystem(
-                anon=False,
-            )
+        client_kwargs = {}
+        if self.endpoint_url:
+            client_kwargs["endpoint_url"] = self.endpoint_url
+
+        return S3FileSystem(
+            anon=False,
+            client_kwargs=client_kwargs,
+        )
 
     def _url_for(self, key) -> str:
         return self._fs.url(

--- a/tests/test_get_store_from_url.py
+++ b/tests/test_get_store_from_url.py
@@ -1,0 +1,39 @@
+from typing import Callable
+
+import pytest
+
+from minimalkv._get_store import get_store
+from minimalkv._get_store import get_store_from_url as get_store_from_url_new
+from minimalkv._hstores import HDictStore
+from minimalkv._key_value_store import KeyValueStore
+from minimalkv._urls import url2dict
+from minimalkv.memory import DictStore
+
+
+# Monkey patch equality operator for testing purposes.
+def _eq_dict_store(self: object, other: object) -> bool:
+    if isinstance(self, DictStore):
+        if isinstance(other, DictStore):
+            return self.d == other.d
+    raise NotImplementedError
+
+
+DictStore.__eq__ = _eq_dict_store  # type: ignore
+
+
+def get_store_from_url_old(url: str) -> KeyValueStore:
+    return get_store(**url2dict(url))
+
+
+@pytest.fixture(params=[get_store_from_url_new, get_store_from_url_old])
+def get_store_from_url(request) -> Callable:
+    return request.param
+
+
+@pytest.mark.parametrize(
+    "url, key_value_store", [("memory://", DictStore()), ("hmemory://", HDictStore())]
+)
+def test_get_store_from_url(
+    url: str, key_value_store: KeyValueStore, get_store_from_url: Callable
+) -> None:
+    assert get_store_from_url(url) == key_value_store


### PR DESCRIPTION
This is necessary when you have a custom S3 deployment with, for example, [MinIO](https://min.io/) or [Apache Ozone](https://ozone.apache.org/).

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a `docs/changes.rst` entry
