### PR TITLE
Add option to disable SSL verification for S3Store

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,7 +4,7 @@ Changelog
 1.8.0
 =====
 * Fixed the behaviour of ``S3FSStore`` when providing a custom endpoint.
-* Added ``verify`` constructor argument to ``S3FSStore`` that disables SSL verification. Use it in an URI as ``?verify=False``.
+* Added ``verify`` constructor argument to ``S3FSStore`` that disables SSL verification. Use it in an URI as ``?verify=false``.
 
 1.7.0
 =====

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,6 +4,7 @@ Changelog
 1.8.0
 =====
 * Fixed the behaviour of ``S3FSStore`` when providing a custom endpoint.
+* Added ``verify`` constructor argument to ``S3FSStore`` that disables SSL verification. Use it in an URI as ``?verify=False``.
 
 1.7.0
 =====

--- a/minimalkv/net/s3fsstore.py
+++ b/minimalkv/net/s3fsstore.py
@@ -32,6 +32,7 @@ class S3FSStore(FSSpecStore, UrlMixin):  # noqa D
         reduced_redundancy=False,
         public=False,
         metadata=None,
+        verify=True,
     ):
         if isinstance(bucket, str):
             import boto3
@@ -47,6 +48,7 @@ class S3FSStore(FSSpecStore, UrlMixin):  # noqa D
         self.reduced_redundancy = reduced_redundancy
         self.public = public
         self.metadata = metadata or {}
+        self.verify = verify
 
         # Get endpoint URL
         self.endpoint_url = self.bucket.meta.client.meta.endpoint_url
@@ -66,7 +68,7 @@ class S3FSStore(FSSpecStore, UrlMixin):  # noqa D
         if not has_s3fs:
             raise ImportError("Cannot find optional dependency s3fs.")
 
-        client_kwargs = {}
+        client_kwargs = {"verify": self.verify}
         if self.endpoint_url:
             client_kwargs["endpoint_url"] = self.endpoint_url
 
@@ -187,4 +189,6 @@ class S3FSStore(FSSpecStore, UrlMixin):  # noqa D
         # The bucket will be created in the `create_filesystem` method if it doesn't exist.
         bucket = resource.Bucket(bucket_name)
 
-        return cls(bucket)
+        verify = query.get("verify", "true").lower() == "true"
+
+        return cls(bucket, verify=verify)

--- a/tests/store_creation/test_creation_boto3store.py
+++ b/tests/store_creation/test_creation_boto3store.py
@@ -7,7 +7,7 @@ from minimalkv.net.s3fsstore import S3FSStore
 
 storage = pytest.importorskip("google.cloud.storage")
 
-S3_URL = "s3://minio:miniostorage@127.0.0.1:9000/bucketname?create_if_missing=true&is_secure=false"
+S3_URL = "s3://minio:miniostorage@127.0.0.1:9000/bucketname?create_if_missing=true&is_secure=false&verify=False"
 
 """
 When using the `s3` scheme in a URL, the new store creation returns an `S3FSStore`.
@@ -26,6 +26,7 @@ def test_new_s3fs_creation():
             bucket_name="bucketname-minio",
             is_secure=False,
         ),
+        verify=False,
     )
 
     actual = get_store_from_url(S3_URL)

--- a/tests/store_creation/test_creation_boto3store.py
+++ b/tests/store_creation/test_creation_boto3store.py
@@ -7,7 +7,7 @@ from minimalkv.net.s3fsstore import S3FSStore
 
 storage = pytest.importorskip("google.cloud.storage")
 
-S3_URL = "s3://minio:miniostorage@127.0.0.1:9000/bucketname?create_if_missing=true&is_secure=false&verify=False"
+S3_URL = "s3://minio:miniostorage@127.0.0.1:9000/bucketname?create_if_missing=true&is_secure=false&verify=false"
 
 """
 When using the `s3` scheme in a URL, the new store creation returns an `S3FSStore`.


### PR DESCRIPTION
It's not always possible (or, at least, not convenient) to deal with SSL verification when the certificates are self-signed. This PR adds an option to disable SSL verification.

Depends on #81.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Added a `docs/changes.rst` entry
