### PR TITLE
Implement _from_parsed_url for (H)DictStore and add test

### DIFF
--- a/minimalkv/memory/__init__.py
+++ b/minimalkv/memory/__init__.py
@@ -1,6 +1,8 @@
 from io import BytesIO
 from typing import Dict, Iterator, Optional
 
+from uritools import SplitResult
+
 from minimalkv import CopyMixin, KeyValueStore
 
 
@@ -43,3 +45,9 @@ class DictStore(KeyValueStore, CopyMixin):
 
         """
         return filter(lambda k: k.startswith(prefix), iter(self.d))
+
+    @classmethod
+    def _from_parsed_url(
+        cls, parsed_url: SplitResult, query: Dict[str, str]
+    ) -> "DictStore":
+        return cls()

--- a/tests/test_get_store_from_url.py
+++ b/tests/test_get_store_from_url.py
@@ -1,0 +1,39 @@
+from typing import Callable
+
+import pytest
+
+from minimalkv._get_store import get_store
+from minimalkv._get_store import get_store_from_url as get_store_from_url_new
+from minimalkv._hstores import HDictStore
+from minimalkv._key_value_store import KeyValueStore
+from minimalkv._urls import url2dict
+from minimalkv.memory import DictStore
+
+
+# Monkey patch equality operator for testing purposes.
+def _eq_dict_store(self: object, other: object) -> bool:
+    if isinstance(self, DictStore):
+        if isinstance(other, DictStore):
+            return self.d == other.d
+    raise NotImplementedError
+
+
+DictStore.__eq__ = _eq_dict_store  # type: ignore
+
+
+def get_store_from_url_old(url: str) -> KeyValueStore:
+    return get_store(**url2dict(url))
+
+
+@pytest.fixture(params=[get_store_from_url_new, get_store_from_url_old])
+def get_store_from_url(request) -> Callable:
+    return request.param
+
+
+@pytest.mark.parametrize(
+    "url, key_value_store", [("memory://", DictStore()), ("hmemory://", HDictStore())]
+)
+def test_get_store_from_url(
+    url: str, key_value_store: KeyValueStore, get_store_from_url: Callable
+) -> None:
+    assert get_store_from_url(url) == key_value_store


### PR DESCRIPTION
A first attempt at implementing `_from_parsed_url` for all stores. Here we start with the `DictStore` and also add a simple test scaffold.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Added a `docs/changes.rst` entry
