### PR TITLE
fix boto3 import by moving to classmethod

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -5,6 +5,7 @@ Changelog
 =====
 * Fixed the behaviour of ``S3FSStore`` when providing a custom endpoint.
 * Added ``verify`` constructor argument to ``S3FSStore`` that disables SSL verification. Use it in an URI as ``?verify=false``.
+* Fixing ``boto3`` import at module level of `s3fsstore`.
 
 1.7.0
 =====

--- a/minimalkv/net/s3fsstore.py
+++ b/minimalkv/net/s3fsstore.py
@@ -2,7 +2,6 @@ import os
 import warnings
 from typing import Dict
 
-import boto3
 from uritools import SplitResult
 
 from minimalkv import UrlMixin
@@ -129,6 +128,7 @@ class S3FSStore(FSSpecStore, UrlMixin):  # noqa D
         store : S3FSStore
             The created S3FSStore.
         """
+        import boto3
 
         url_access_key_id = _get_username(parsed_url)
         url_secret_access_key = _get_password(parsed_url)


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

- fixing module level import of `boto3` which currently breaks also [conda releases](https://github.com/conda-forge/minimalkv-feedstock/pull/21).

Checklist
* [x] Added a `docs/changes.rst` entry
