### PR TITLE
switch from `pkg_resources` to `importlib.metadata`

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -1,6 +1,10 @@
 Changelog
 *********
 
+1.8.1
+=====
+* Drop `pkg_resources` and use `importlib.metadata` to access package version string.
+
 1.8.0
 =====
 * Fixed the behaviour of ``S3FSStore`` when providing a custom endpoint.

--- a/minimalkv/__init__.py
+++ b/minimalkv/__init__.py
@@ -13,11 +13,12 @@ from minimalkv._store_decoration import decorate_store
 from minimalkv._urls import url2dict
 
 try:
-    import pkg_resources
+    import importlib.metadata
 
-    __version__ = pkg_resources.get_distribution(__name__).version
-except Exception:  # pragma: no cover
+    __version__ = importlib.metadata.version(__name__)
+except Exception:
     __version__ = "unknown"
+
 
 __all__ = [
     "CopyMixin",


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

- minor change dropping `pkg_resources` and switching to `importlib.metadata` to look up package version string. This solves deprecation warnings emitted by `pkg_resources`.

Checklist
* [x] Added a `docs/changes.rst` entry
