### PR TITLE
propagate s3 region name to obey AWS location constraints on AWS S3 endpoints

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -6,6 +6,7 @@ Changelog
 * Drop `pkg_resources` and use `importlib.metadata` to access package version string.
 * Add missing `region_name` in `s3fs` store creation to set required location contraint
   during bucket creation.
+
 1.8.0
 =====
 * Fixed the behaviour of ``S3FSStore`` when providing a custom endpoint.

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,7 +4,8 @@ Changelog
 1.8.1
 =====
 * Drop `pkg_resources` and use `importlib.metadata` to access package version string.
-
+* Add missing `region_name` in `s3fs` store creation to set required location contraint
+  during bucket creation.
 1.8.0
 =====
 * Fixed the behaviour of ``S3FSStore`` when providing a custom endpoint.

--- a/minimalkv/_get_store.py
+++ b/minimalkv/_get_store.py
@@ -48,7 +48,7 @@ def get_store_from_url(
         * AzureBlockBlockStorage (SAS): ``azure://account_name:shared_access_signature@container?use_sas&create_if_missing=false[?max_connections=2&socket_timeout=(20,100)]``
         * AzureBlockBlockStorage (SAS): ``azure://account_name:shared_access_signature@container?use_sas&create_if_missing=false[?max_connections=2&socket_timeout=(20,100)][?max_block_size=4*1024*1024&max_single_put_size=64*1024*1024]``
         * GoogleCloudStorage: ``gcs://<base64 encoded credentials JSON>@bucket_name[?create_if_missing=true][&bucket_creation_location=EUROPE-WEST1]``
-        * S3FSStore ``s3://access_key:secret_key@endpoint/bucket[?create_if_missing=true]``
+        * S3FSStore ``s3://access_key:secret_key@endpoint/bucket[?create_if_missing=true][&region_name=...]``
 
     See the respective store's :func:`_from_parsed_url` function for more details.
 

--- a/minimalkv/net/s3fsstore.py
+++ b/minimalkv/net/s3fsstore.py
@@ -32,6 +32,7 @@ class S3FSStore(FSSpecStore, UrlMixin):  # noqa D
         public=False,
         metadata=None,
         verify=True,
+        region_name=None,
     ):
         if isinstance(bucket, str):
             import boto3
@@ -48,6 +49,7 @@ class S3FSStore(FSSpecStore, UrlMixin):  # noqa D
         self.public = public
         self.metadata = metadata or {}
         self.verify = verify
+        self.region_name = region_name
 
         # Get endpoint URL
         self.endpoint_url = self.bucket.meta.client.meta.endpoint_url
@@ -70,7 +72,8 @@ class S3FSStore(FSSpecStore, UrlMixin):  # noqa D
         client_kwargs = {"verify": self.verify}
         if self.endpoint_url:
             client_kwargs["endpoint_url"] = self.endpoint_url
-
+        if self.region_name:
+            client_kwargs["region_name"] = self.region_name
         return S3FileSystem(
             anon=False,
             client_kwargs=client_kwargs,
@@ -112,6 +115,8 @@ class S3FSStore(FSSpecStore, UrlMixin):  # noqa D
         ``create_if_missing`` (default: ``True`` ): If set, creates the bucket if it does not exist;
          otherwise, try to retrieve the bucket and fail with an ``IOError``.
 
+        ``region_name`` (default: ``None``): If set the AWS region name is applied as location
+        constraint during bucket creation.
         **Notes**:
 
         If the scheme is ``hs3``, an ``HS3FSStore`` is returned which allows ``/`` in key names.
@@ -187,8 +192,10 @@ class S3FSStore(FSSpecStore, UrlMixin):  # noqa D
 
         # We only create a reference to the bucket here.
         # The bucket will be created in the `create_filesystem` method if it doesn't exist.
+        region_name = query.get("region_name")
+
         bucket = resource.Bucket(bucket_name)
 
         verify = query.get("verify", "true").lower() == "true"
 
-        return cls(bucket, verify=verify)
+        return cls(bucket, verify=verify, region_name=region_name)


### PR DESCRIPTION
Current `s3fs` store implementation does not provide any option to propagate the AWS S3 `region_name` to the underlying `S3FileSystem`. This PR adds to possiblity to add a region name as query parameter and propagates this to the `S3FileSystem` backend.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a `docs/changes.rst` entry
