### PR TITLE
Changing return type of `__iter__` to `Iterator`.

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -1,6 +1,10 @@
 Changelog
 *********
 
+1.8.3
+=====
+* Changed `__iter__` return type to `Iterator`.
+
 1.8.2
 =====
 * Include Python 3.12 in CI

--- a/minimalkv/_key_value_store.py
+++ b/minimalkv/_key_value_store.py
@@ -1,6 +1,6 @@
 from io import BytesIO
 from types import TracebackType
-from typing import IO, Dict, Iterable, Iterator, List, Optional, Type, Union
+from typing import IO, Dict, Iterator, List, Optional, Type, Union
 
 from uritools import SplitResult
 
@@ -37,7 +37,7 @@ class KeyValueStore:
         self._check_valid_key(key)
         return self._has_key(key)
 
-    def __iter__(self) -> Iterable[str]:
+    def __iter__(self) -> Iterator[str]:
         """Iterate over all keys in the store.
 
         Raises

--- a/minimalkv/decorator.py
+++ b/minimalkv/decorator.py
@@ -1,5 +1,5 @@
 from types import TracebackType
-from typing import Iterable, Optional, Type
+from typing import Iterable, Iterator, Optional, Type
 from urllib.parse import quote_plus, unquote_plus
 
 from minimalkv._key_value_store import KeyValueStore
@@ -36,7 +36,7 @@ class StoreDecorator:
     def __contains__(self, key: str) -> bool:  # noqa D
         return self._dstore.__contains__(key)
 
-    def __iter__(self) -> Iterable[str]:  # noqa D
+    def __iter__(self) -> Iterator[str]:  # noqa D
         return self._dstore.__iter__()
 
     def close(self):
@@ -80,7 +80,7 @@ class KeyTransformingDecorator(StoreDecorator):  # noqa D
     def __contains__(self, key: str) -> bool:  # noqa D
         return self._map_key(key) in self._dstore
 
-    def __iter__(self) -> Iterable[str]:  # noqa D
+    def __iter__(self) -> Iterator[str]:  # noqa D
         return self.iter_keys()
 
     def delete(self, key: str):  # noqa D
@@ -92,7 +92,7 @@ class KeyTransformingDecorator(StoreDecorator):  # noqa D
     def get_file(self, key: str, *args, **kwargs):  # noqa D
         return self._dstore.get_file(self._map_key(key), *args, **kwargs)
 
-    def iter_keys(self, prefix: str = "") -> Iterable[str]:  # noqa D
+    def iter_keys(self, prefix: str = "") -> Iterator[str]:  # noqa D
         return (
             self._unmap_key(k)
             for k in self._dstore.iter_keys(self._map_key_prefix(prefix))


### PR DESCRIPTION
The previous return type of `Iterable` is incorrect as can be seen in this example:
https://docs.python.org/3/library/typing.html#nominal-vs-structural-subtyping

Also this documentation mentions that `__iter__` returns the iterator object itself:
https://docs.python.org/3/library/stdtypes.html#iterator.__iter__

The incorrect `Iterable` type causes numerous of error when analyzed by a static type checker such as `mypy`. The switch to `Iterator` solves these issues.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a `docs/changes.rst` entry
