### PR TITLE
Removing invalid `BSD-3 Clause` license classifier.

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -1,6 +1,10 @@
 Changelog
 *********
 
+1.8.4
+=====
+* Removing invalid BSD-3 Clause license classifier.
+
 1.8.3
 =====
 * Changed `__iter__` return type to `Iterator`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ readme = "README.rst"
 authors = [{name = "Data Engineering Collective", email = "minimalkv@uwekorn.com"}]
 classifiers = [
     "License :: OSI Approved :: BSD License",
-    "License :: OSI Approved :: BSD-3 Clause",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
According to the pypi list of standardized classifiers, the classifier `License :: OSI Approved :: BSD-3 Clause` is invalid.

This is also made clear by looking at the two latest publish package steps, which both failed with the following error:

```
HTTPError: 400 Bad Request from https://upload.pypi.org/legacy/
Invalid value for classifiers. Error: Classifier 'License :: OSI
Approved :: BSD-3 Clause' is not a valid classifier.
```

Removing this classifier should make the package valid for publishing again as all remaining classifiers are valid.

See: https://pypi.org/classifiers/

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a `docs/changes.rst` entry
