### PR TITLE
Undeprecate url2dict and get_store_from_url

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -1,6 +1,11 @@
 Changelog
 *********
 
+1.8.6
+=====
+* We undeprecated ``url2dict`` and ``extract_params`` as these functions turned
+  out to be useful in downstream projects.
+
 1.8.5
 =====
 * Changed generic `IO` type to `BinaryIO`.

--- a/minimalkv/_urls.py
+++ b/minimalkv/_urls.py
@@ -1,6 +1,5 @@
 import base64
 from typing import Any, Dict, List
-from warnings import warn
 
 from uritools import urisplit
 
@@ -34,15 +33,6 @@ def url2dict(url: str, raise_on_extra_params: bool = False) -> Dict[str, Any]:
         ``azure://account_name:shared_access_signature@container?use_sas&create_if_missing=false[?max_connections=2&socket_timeout=(20,100)][?max_block_size=4*1024*1024&max_single_put_size=64*1024*1024]``
         ``gcs://<base64 encoded credentialsJSON>@bucket_name[?create_if_missing=true][?bucket_creation_location=EUROPE-WEST1]``
     """
-    warn(
-        """
-        url2dict will be removed in the next major release.
-        If you want to create a KeyValueStore from a URL, use get_store_from_url.
-        """,
-        DeprecationWarning,
-        stacklevel=2,
-    )
-
     u = urisplit(url)
     parsed = {
         "scheme": u.getscheme(),
@@ -77,15 +67,6 @@ def url2dict(url: str, raise_on_extra_params: bool = False) -> Dict[str, Any]:
 
 
 def extract_params(scheme, host, port, path, query, userinfo):  # noqa D
-    warn(
-        """
-        extract_params will be removed in the next major release.
-        If you want to create a KeyValueStore from a URL, use get_store_from_url.
-        """,
-        DeprecationWarning,
-        stacklevel=2,
-    )
-
     # We want to ignore wrappers here
     store_type = scheme.split("+")[0]
 
@@ -159,14 +140,6 @@ def _parse_userinfo(userinfo: str) -> List[str]:
     parts: list of str
         URL-encoded user-info split at ``:``.
     """
-    warn(
-        """
-        _parse_userinfo will be removed in the next major release.
-        If you want to create a KeyValueStore from a URL, use get_store_from_url.
-        """,
-        DeprecationWarning,
-        stacklevel=2,
-    )
     if hasattr(userinfo, "split"):
         parts = userinfo.split(":", 1)
 


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a `docs/changes.rst` entry

These functions are useful in our downstream projects and replacing them requires a lot of boilerplate code.