### PR TITLE
Add an option to use STS credentials

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
           while ! docker exec mysql mysqladmin status -h 127.0.0.1 -u minimalkv_test --password=minimalkv_test; \
             do sleep 3; done
       - name: Run pytest
-        run: pixi run -e ${{ matrix.environment }} pytest -n auto --dist loadfile -rs --cov=minimalkv --cov-report=xml --color=yes
+        run: pixi run -e ${{ matrix.environment }} pytest -n auto --dist loadfile -rs --cov=minimalkv --cov-report=xml --color=yes --cov-report=term-missing
       - uses: codecov/codecov-action@v5
         with:
           file: ./coverage.xml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
       # ruff
       - id: ruff
         name: ruff
-        entry: pixi run -e lint ruff check --fix --exit-non-zero-on-fix --force-exclude
+        entry: pixi run -e lint ruff check --fix --exit-non-zero-on-fix --force-exclude --unsafe-fixes
         language: system
         types_or: [python, pyi]
         require_serial: true

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -1,8 +1,8 @@
 Changelog
 *********
 
-
-1.10.1
+.. Wait until the no side effects PR is merged
+1.1X.0
 ======
 * Add option to pass STS credentials to ``s3://`` store by setting the ``is_sts_credentials=true`` url param and passing role params via ``sts_assume_role__*``, e.g. ``sts_assume_role__RoleArn=...``.
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -1,10 +1,14 @@
 Changelog
 *********
 
+
+1.10.1
+======
+* Add option to pass STS credentials to ``s3://`` store by setting the ``is_sts_credentials=true`` url param and passing role params via ``sts_assume_role__*``, e.g. ``sts_assume_role__RoleArn=...``.
+
 1.9.2
 =====
 * Port setup to use the OSS QuantCo copier template (`copier template https://github.com/Quantco/copier-template-python-open-source`_) and (`pixi https://pixi.sh`_) as environment manager.
-
 
 1.9.1
 =====

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -132,6 +132,7 @@ Table of contents
    boto
    azure
    gcstorage
+   s3fsstore
    memory
    db
    git

--- a/docs/s3fsstore.rst
+++ b/docs/s3fsstore.rst
@@ -1,0 +1,67 @@
+
+S3 Store
+========
+
+The S3FSStore class in the minimalkv library provides a mechanism to interact with an S3-compatible (e.g. AWS or minio) storage system using the s3fs library.
+
+The preferred initialization method is to use the ``get_store_from_url`` function, which will parse the URL and return an instance of the appropriate store class.
+
+Possible options for the URL are (newline separated for readability):
+
+::
+
+    s3://access_key:secret_key@endpoint/bucket
+    [?create_if_missing=true]
+    [&region_name=region-name]
+    [&force_bucket_suffix=true|false]
+    [&session_token=session-token]
+    [&is_sts_credentials=true|false]
+    [&sts_assume_role__RoleArn=role-arn]
+    [&sts_assume_role__RoleSessionName=session-name]
+    [&sts_assume_role__DurationSeconds=duration-in-seconds]
+    [&sts_assume_role__[KEY]=[VALUE]]
+    [&verify=true|false]
+
+::
+
+    from minimalkv import get_store_from_url
+
+    store = get_store_from_url(
+        "s3://access_key_id:secret_access_key@endpoint/bucket-name"
+    )
+    store.put("example-key", b"example content")
+    print(store.get("example-key"))
+
+
+STS Credentials
+===============
+
+::
+
+    from minimalkv import get_store_from_url
+
+    store = get_store_from_url(
+        "s3://access_key_id:secret_access_key@endpoint/bucket-name"
+        "?is_sts_credentials=true"
+        "&sts_assume_role__RoleArn=arn:aws:iam::123456789012:role/MyRole"
+        "&sts_assume_role__RoleSessionName=MySession"
+        "&sts_assume_role__DurationSeconds=900"
+    )
+
+    store.put("example-key", b"example content")
+    print(store.get("example-key"))
+
+
+If you want to pass nested attributes or lists as parameters, you should import
+the ``S3FSStore`` directly, i.e. ``from minimalkv.net.s3fsstore import S3FSStore``.
+
+
+Local Testing
+=============
+
+::
+
+    AWS_PROFILE={$MINIMALKV_PROFILE} pixi run pytest [--log-cli-level=INFO]
+
+Include AWS_PROFILE or provide AWS credentials in the environment variables, otherwise
+integration tests for AWS S3 will be skipped.

--- a/minimalkv/net/_aws_refreshable_session.py
+++ b/minimalkv/net/_aws_refreshable_session.py
@@ -1,0 +1,122 @@
+# Copyright (c) QuantCo 2024-2024
+# SPDX-License-Identifier: LicenseRef-QuantCo
+
+from datetime import datetime
+from logging import getLogger
+from typing import Dict, Optional
+
+from aiobotocore.credentials import (
+    AioRefreshableCredentials,
+    CredentialResolver,
+    create_assume_role_refresher,
+)
+from aiobotocore.session import AioSession
+from botocore.credentials import CredentialProvider
+from dateutil import tz  # type: ignore[import-untyped]
+
+logger = getLogger(__name__)
+
+
+class RefreshableAssumeRoleProvider(CredentialProvider):
+    """A credential provider that loads self-refreshing credentials using 'sts.assume_role'.
+
+    The credentials are obtained in the '_refresh' method using the given `sts_session`
+    and 'assume_role_params' to assume a role.
+    Whenever a refresh is needed, the credentials are obtained
+    again by assuming the role again through the `sts_session`.
+
+    This means that if the given `sts_session` is expired, the refreshable credentials
+    also won't be able to refresh themselves.
+    """
+
+    METHOD = "refreshable-assume-role"
+
+    def __init__(
+        self,
+        sts_session: AioSession,
+        assume_role_params: Dict,
+        advisory_timeout: Optional[int] = None,
+        mandatory_timeout: Optional[int] = None,
+    ):
+        self.sts_session = sts_session
+        self._assume_role_params = assume_role_params
+        self.advisory_timeout = advisory_timeout
+        self.mandatory_timeout = mandatory_timeout
+
+        super().__init__()
+
+    async def load(self) -> AioRefreshableCredentials:
+        refresh = self.create_refresh()
+
+        refreshable_credentials = AioRefreshableCredentials.create_from_metadata(
+            metadata=await refresh(),
+            refresh_using=refresh,
+            method=self.METHOD,
+            advisory_timeout=self.advisory_timeout,
+            mandatory_timeout=self.mandatory_timeout,
+        )
+
+        return refreshable_credentials
+
+    def create_refresh(self):
+        async def _refresh() -> Dict:
+            logger.debug("Refreshing credentials")
+            sts_client = self.sts_session.create_client("sts")
+            refresh = create_assume_role_refresher(sts_client, self._assume_role_params)
+
+            credentials = await refresh()
+            to_zone = tz.tzlocal()
+            local_expiry_time = (
+                datetime.strptime(credentials["expiry_time"], "%Y-%m-%dT%H:%M:%S%Z")
+                .replace(tzinfo=tz.tzutc())
+                .astimezone(to_zone)
+            )
+            logger.debug(
+                f"""Refreshed credentials with access key '{credentials["access_key"]}' and expiry time '{local_expiry_time}'."""
+            )
+            return credentials
+
+        return _refresh
+
+
+def create_aio_session_w_refreshable_credentials(
+    access_key: str,
+    secret_key: str,
+    token: Optional[str],
+    assume_role_params: Dict,
+    advisory_timeout: Optional[int] = None,
+    mandatory_timeout: Optional[int] = None,
+):
+    """Create an aio session that knows how to refresh its credentials using 'sts.assume_role'.
+
+    The 'aws_credentials' are used to assume a role (specified by assume_role_params)
+    and if refresh is needed, the session will use the credentials to assume the role
+    again.
+
+    This means that if the given 'aws_credentials' are expired, the returned session
+    also won't be able to refresh its credentials.
+    """
+    # This session is used to provide the refresh mechanism
+    sts_session = AioSession()
+    sts_session.set_credentials(
+        access_key=access_key,
+        secret_key=secret_key,
+        token=token,
+    )
+
+    # Actual session with refreshable credentials
+    session = AioSession()
+    resolver = CredentialResolver(
+        providers=[
+            RefreshableAssumeRoleProvider(
+                sts_session, assume_role_params, advisory_timeout, mandatory_timeout
+            )
+        ]
+        # Only offer 1 way of retrieving credentials
+        # => Do not need to worry about "side-effects" anymore
+    )
+    session.register_component(
+        "credential_provider", resolver
+    )  # "registering" replaces the current credential provider with our resolver
+
+    return session

--- a/minimalkv/net/_aws_refreshable_session.py
+++ b/minimalkv/net/_aws_refreshable_session.py
@@ -3,7 +3,7 @@
 
 from datetime import datetime
 from logging import getLogger
-from typing import Dict, Optional
+from typing import Optional
 
 from aiobotocore.credentials import (
     AioRefreshableCredentials,
@@ -34,7 +34,7 @@ class RefreshableAssumeRoleProvider(CredentialProvider):
     def __init__(
         self,
         sts_session: AioSession,
-        assume_role_params: Dict,
+        assume_role_params: dict,
         advisory_timeout: Optional[int] = None,
         mandatory_timeout: Optional[int] = None,
     ):
@@ -59,8 +59,8 @@ class RefreshableAssumeRoleProvider(CredentialProvider):
         return refreshable_credentials
 
     def create_refresh(self):
-        async def _refresh() -> Dict:
-            logger.debug("Refreshing credentials")
+        async def _refresh() -> dict:
+            logger.info("Refreshing credentials")
             sts_client = self.sts_session.create_client("sts")
             refresh = create_assume_role_refresher(sts_client, self._assume_role_params)
 
@@ -71,7 +71,7 @@ class RefreshableAssumeRoleProvider(CredentialProvider):
                 .replace(tzinfo=tz.tzutc())
                 .astimezone(to_zone)
             )
-            logger.debug(
+            logger.info(
                 f"""Refreshed credentials with access key '{credentials["access_key"]}' and expiry time '{local_expiry_time}'."""
             )
             return credentials
@@ -83,7 +83,7 @@ def create_aio_session_w_refreshable_credentials(
     access_key: str,
     secret_key: str,
     token: Optional[str],
-    assume_role_params: Dict,
+    assume_role_params: dict,
     advisory_timeout: Optional[int] = None,
     mandatory_timeout: Optional[int] = None,
 ):

--- a/minimalkv/net/s3fsstore.py
+++ b/minimalkv/net/s3fsstore.py
@@ -7,6 +7,9 @@ from uritools import SplitResult
 from minimalkv import UrlMixin
 from minimalkv._url_utils import _get_password, _get_username
 from minimalkv.fsspecstore import FSSpecStore
+from minimalkv.net._aws_refreshable_session import (
+    create_aio_session_w_refreshable_credentials,
+)
 
 try:
     from s3fs import S3FileSystem
@@ -20,6 +23,13 @@ warnings.warn(
     category=DeprecationWarning,
     stacklevel=2,
 )
+
+
+def _removeprefix(text: str, prefix: str) -> str:
+    # TODO: Remove when Python 3.9 is the minimum supported version
+    if text.startswith(prefix):
+        return text[len(prefix) :]
+    return text
 
 
 class Credentials(NamedTuple):
@@ -50,6 +60,8 @@ class S3FSStore(FSSpecStore, UrlMixin):  # noqa D
         metadata=None,
         verify=True,
         region_name=None,
+        is_sts_credentials: bool = False,
+        sts_assume_role_params: Optional[Dict[str, str]] = None,
     ):
         if isinstance(bucket, str):
             import boto3
@@ -69,6 +81,8 @@ class S3FSStore(FSSpecStore, UrlMixin):  # noqa D
         self.metadata = metadata or {}
         self.verify = verify
         self.region_name = region_name
+        self._is_sts_credentials = is_sts_credentials
+        self._sts_assume_role_params = sts_assume_role_params
 
         # Get endpoint URL
         self.endpoint_url = self.bucket.meta.client.meta.endpoint_url
@@ -93,6 +107,40 @@ class S3FSStore(FSSpecStore, UrlMixin):  # noqa D
             client_kwargs["endpoint_url"] = self.endpoint_url
         if self.region_name:
             client_kwargs["region_name"] = self.region_name
+
+        if self._is_sts_credentials:
+            assert (
+                self.credentials is not None
+                and self.credentials.access_key_id
+                and self.credentials.secret_access_key
+            ), (
+                "If `is_sts_credentials` is set, you need to provide "
+                "'sts' credentials explicitly. At least access key and secret key are required."
+            )
+
+            assert self._sts_assume_role_params is not None, (
+                "If `is_sts_credentials` is set, you need to provide "
+                "`sts_assume_role_params`. At least, you need to provide "
+                "the `RoleArn`. If you created the store from a URL, "
+                "you can pass these parameters as query arguments with the prefix "
+                "`sts_assume_role__`, e.g. `sts_assume_role__RoleArn=arn:aws:iam:...`"
+            )
+
+            session = create_aio_session_w_refreshable_credentials(
+                access_key=self.credentials.access_key_id,
+                secret_key=self.credentials.secret_access_key,
+                token=self.credentials.session_token,
+                assume_role_params=self._sts_assume_role_params,
+                # TODO: allow to pass this as well?
+                advisory_timeout=None,
+                mandatory_timeout=None,
+            )
+            return S3FileSystem(
+                anon=False,
+                client_kwargs=client_kwargs,
+                use_ssl=self.verify,
+                session=session,
+            )
 
         if self.credentials:
             return S3FileSystem(
@@ -152,6 +200,12 @@ class S3FSStore(FSSpecStore, UrlMixin):  # noqa D
         ``session_token``(default: ``None``): If set this token will be used in conjunction
         with access_key_id and secret_access_key for authentication.
 
+        ``is_sts_credentials`` (default: ``False``): If set, the credentials are assumed to be
+
+        ``sts_assume_role__*``: Replace * with the respective parameter name expected by
+        the assume role endpoint, e.g. ``sts_assume_role__RoleArn=arn:aws:iam:...`.
+        All parameters passed following this pattern will be passed to the assume role endpoint.
+
         **Notes**:
 
         If the scheme is ``hs3``, an ``HS3FSStore`` is returned which allows ``/`` in key names.
@@ -197,6 +251,13 @@ class S3FSStore(FSSpecStore, UrlMixin):  # noqa D
             secret_access_key=url_secret_access_key,
             session_token=url_session_token,
         )
+
+        is_sts_credentials = query.get("is_sts_credentials", "").lower() == "true"
+        sts_assume_role_params = {
+            _removeprefix(key, "sts_assume_role__"): value
+            for key, value in query.items()
+            if key.startswith("sts_assume_role__")
+        } or None  # none as explicit default instead of {}
 
         boto3_params = credentials.as_boto3_params()
         host = parsed_url.gethost()
@@ -246,5 +307,10 @@ class S3FSStore(FSSpecStore, UrlMixin):  # noqa D
         verify = query.get("verify", "true").lower() == "true"
 
         return cls(
-            bucket, credentials=credentials, verify=verify, region_name=region_name
+            bucket,
+            credentials=credentials,
+            verify=verify,
+            region_name=region_name,
+            is_sts_credentials=is_sts_credentials,
+            sts_assume_role_params=sts_assume_role_params,
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,8 +67,10 @@ no_implicit_optional = true
 check_untyped_defs = true
 
 [tool.pytest.ini_options]
-addopts = "-m 'not slow' --strict-markers"
-markers = ["slow: marks test as slow to run"]
+addopts = "--strict-markers"
+markers = [
+  "slow: marks test as slow to run",
+]
 testpaths = ["tests"]
 
 [tool.typos]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,8 @@ no_implicit_optional = true
 check_untyped_defs = true
 
 [tool.pytest.ini_options]
+addopts = "-m 'not slow' --strict-markers"
+markers = ["slow: marks test as slow to run"]
 testpaths = ["tests"]
 
 [tool.typos]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,9 +68,7 @@ check_untyped_defs = true
 
 [tool.pytest.ini_options]
 addopts = "--strict-markers"
-markers = [
-  "slow: marks test as slow to run",
-]
+markers = ["slow: marks test as slow to run"]
 testpaths = ["tests"]
 
 [tool.typos]


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a `docs/changes.rst` entry
* [x] Adjust version in changes.rst after #128 is merged

For now, I would just keep the long running integration test for the STS credentials in the basic test setup. If #143 is addressed, we can think about refactoring the ci workflow, s.t. that this specific integration test gets its own job.