### PR TITLE
Remove publishing to test pypi

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,12 +41,6 @@ jobs:
         with:
           name: artifact
           path: dist
-      - name: Publish package on TestPyPi
-        uses: pypa/gh-action-pypi-publish@67339c736fd9354cd4f8cb0b744f2b82a74b5c70 # v1.12.3
-        with:
-          repository-url: https://test.pypi.org/legacy/
-          user: __token__
-          password: ${{ secrets.pypi_password }}
       - name: Publish package on PyPi
         uses: pypa/gh-action-pypi-publish@67339c736fd9354cd4f8cb0b744f2b82a74b5c70 # v1.12.3
         with:


### PR DESCRIPTION
Addresses inability to publish due to failing publish on test pypi

![image](https://github.com/user-attachments/assets/165193f2-bf41-4345-b4ce-215fa9ef9fa8)

![image](https://github.com/user-attachments/assets/19394254-1433-4f39-85c6-8a6835ee5fbc)

Apparently, minimalkv has no account for test pypi which requires a separate account [^1].


[^1]: https://packaging.python.org/en/latest/guides/using-testpypi/#:~:text=Because%20TestPyPI%20has%20a%20separate%20database%20from%20the%20live%20PyPI%2C%20you%E2%80%99ll%20need%20a%20separate%20user%20account%20specifically%20for%20TestPyPI.