### PR TITLE
Fix S3 environment credential fallback

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -1,6 +1,12 @@
 Changelog
 *********
 
+1.11.2
+======
+* Fix ``S3FSStore`` credential fallback from environment variables when creating
+  ``s3://`` or ``hs3://`` stores without credentials in the URL. The access key
+  ID is now assigned correctly, and ``AWS_SESSION_TOKEN`` is propagated.
+
 1.11.1
 ======
 * Remove hard dependency of aiobotocore in the S3FSStore.

--- a/minimalkv/net/s3fsstore.py
+++ b/minimalkv/net/s3fsstore.py
@@ -260,11 +260,15 @@ class S3FSStore(FSSpecStore, UrlMixin):  # noqa D
         url_session_token = query.get("session_token", None)
 
         if url_access_key_id is None:
-            url_secret_access_key = os.environ.get("AWS_ACCESS_KEY_ID")
-            # We allow attributes to be nonable, a potential use case might be a public bucket
+            url_access_key_id = os.environ.get("AWS_ACCESS_KEY_ID")
+            # We allow attributes to be nonable, a potential use case might be
+            # a public bucket.
 
         if url_secret_access_key is None:
             url_secret_access_key = os.environ.get("AWS_SECRET_ACCESS_KEY")
+
+        if url_session_token is None:
+            url_session_token = os.environ.get("AWS_SESSION_TOKEN")
 
         credentials = Credentials(
             access_key_id=url_access_key_id,

--- a/tests/test_s3fsstore_url_credentials.py
+++ b/tests/test_s3fsstore_url_credentials.py
@@ -1,0 +1,33 @@
+import os
+from unittest import mock
+
+import pytest
+
+import minimalkv
+from minimalkv.net.s3fsstore import S3FSStore
+
+
+@pytest.mark.parametrize("scheme", ["s3", "hs3"])
+def test_s3_url_without_url_credentials_uses_environment_credentials(
+    scheme,
+):
+    with mock.patch.dict(
+        os.environ,
+        {
+            "AWS_ACCESS_KEY_ID": "test-access-key",
+            "AWS_SECRET_ACCESS_KEY": "test-secret-key",
+            "AWS_SESSION_TOKEN": "test-session-token",
+        },
+    ):
+        store = minimalkv.get_store_from_url(
+            f"{scheme}://s3.eu-central-1.amazonaws.com/bucket?force_bucket_suffix=false"
+        )
+
+    assert isinstance(store, S3FSStore)
+    credentials = store.credentials
+    assert credentials is not None
+    assert credentials.as_boto3_params() == {
+        "aws_access_key_id": "test-access-key",
+        "aws_secret_access_key": "test-secret-key",
+        "aws_session_token": "test-session-token",
+    }


### PR DESCRIPTION
## Summary
- Correct the S3 URL parsing fallback so `AWS_ACCESS_KEY_ID` populates the access key instead of the secret key
- Load `AWS_SESSION_TOKEN` from the environment when it is not present in the URL
- Add a higher-level regression test through `get_store_from_url()` for both `s3://` and `hs3://`

## Testing
- Added a unit regression test covering env-derived credentials for the public URL entrypoint
- Local validation previously passed for lint, formatting, mypy, and the focused pytest cases